### PR TITLE
[codex] Implement v0.1.0 model pipeline and CI

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: "en-US"
+early_access: false
+
+reviews:
+  profile: "assertive"
+  request_changes_workflow: true
+  high_level_summary: true
+  review_status: true
+  review_details: true
+  collapse_walkthrough: false
+  auto_review:
+    enabled: true
+    drafts: false
+
+chat:
+  auto_reply: true

--- a/.github/ISSUE_TEMPLATE/feature-slice.yml
+++ b/.github/ISSUE_TEMPLATE/feature-slice.yml
@@ -1,0 +1,40 @@
+name: Feature slice
+description: Track one issue-sized outcome through implementation and CI.
+title: "[Feature]: "
+labels:
+  - enhancement
+body:
+  - type: textarea
+    id: outcome
+    attributes:
+      label: Outcome
+      description: Describe the user-visible result this issue should create.
+      placeholder: A user can...
+    validations:
+      required: true
+  - type: textarea
+    id: expectations
+    attributes:
+      label: Feature expectations
+      description: List outcome-level expectations that should become BDD scenarios when practical.
+      placeholder: |
+        Given...
+        When...
+        Then...
+    validations:
+      required: true
+  - type: textarea
+    id: implementation
+    attributes:
+      label: Implementation notes
+      description: Capture likely modules, APIs, or migration concerns.
+    validations:
+      required: false
+  - type: checkboxes
+    id: done
+    attributes:
+      label: Done when
+      options:
+        - label: Outcome-level BDD coverage exists or the issue explains why it is not applicable.
+        - label: Unit or integration coverage protects important implementation details.
+        - label: CI, Codecov, and CodeRabbit checks pass on the PR.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+## Linked Issue
+
+Closes #
+
+## Outcome
+
+- [ ] The user-visible outcome is described in the linked issue.
+- [ ] BDD feature expectations were added or updated when behavior changed.
+- [ ] Unit or integration coverage was added for implementation details.
+
+## Checks
+
+- [ ] `uv run ruff check`
+- [ ] `uv run mypy src/waccy`
+- [ ] `uv run pytest --cov=src/waccy --cov-report=term-missing --cov-report=xml --cov-fail-under=80`

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,5 @@
+# Pull Request
+
 ## Linked Issue
 
 Closes #
@@ -12,4 +14,5 @@ Closes #
 
 - [ ] `uv run ruff check`
 - [ ] `uv run mypy src/waccy`
+- [ ] `uv run pytest tests/bdd -q -m "bdd or outcome"`
 - [ ] `uv run pytest --cov=src/waccy --cov-report=term-missing --cov-report=xml --cov-fail-under=90`

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,4 +12,4 @@ Closes #
 
 - [ ] `uv run ruff check`
 - [ ] `uv run mypy src/waccy`
-- [ ] `uv run pytest --cov=src/waccy --cov-report=term-missing --cov-report=xml --cov-fail-under=80`
+- [ ] `uv run pytest --cov=src/waccy --cov-report=term-missing --cov-report=xml --cov-fail-under=90`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
@@ -18,18 +17,21 @@ jobs:
   quality:
     name: Quality Gates
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           enable-cache: true
           cache-dependency-glob: uv.lock
@@ -52,7 +54,7 @@ jobs:
           --cov-fail-under=90
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
         with:
           use_oidc: true
           files: ./coverage.xml
@@ -63,18 +65,20 @@ jobs:
   outcome-specs:
     name: BDD Outcome Specs
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           enable-cache: true
           cache-dependency-glob: uv.lock

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
           --cov=src/waccy
           --cov-report=term-missing
           --cov-report=xml
-          --cov-fail-under=80
+          --cov-fail-under=90
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,86 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  quality:
+    name: Quality Gates
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
+      - name: Install dependencies
+        run: uv sync --frozen --dev
+
+      - name: Ruff
+        run: uv run ruff check
+
+      - name: Mypy
+        run: uv run mypy src/waccy
+
+      - name: Tests with coverage
+        run: >
+          uv run pytest
+          --cov=src/waccy
+          --cov-report=term-missing
+          --cov-report=xml
+          --cov-fail-under=80
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          use_oidc: true
+          files: ./coverage.xml
+          flags: python
+          name: waccy-python
+          fail_ci_if_error: true
+
+  outcome-specs:
+    name: BDD Outcome Specs
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
+      - name: Install dependencies
+        run: uv sync --frozen --dev
+
+      - name: Outcome specs
+        run: uv run pytest tests/bdd -q -m "bdd or outcome"

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ env/
 # Testing
 .pytest_cache/
 .coverage
+coverage.xml
 htmlcov/
 .tox/
 .hypothesis/

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ test:
 	uv run pytest
 
 test-cov:
-	uv run pytest --cov=src/waccy --cov-report=term-missing --cov-report=xml --cov-fail-under=80
+	uv run pytest --cov=src/waccy --cov-report=term-missing --cov-report=xml --cov-fail-under=90
 
 bdd:
 	uv run pytest tests/bdd -q -m "bdd or outcome"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+.PHONY: help lint typecheck test test-cov bdd pre-push
+
+help:
+	@echo "Available targets:"
+	@echo "  make lint       - Run ruff"
+	@echo "  make typecheck  - Run mypy"
+	@echo "  make test       - Run pytest"
+	@echo "  make test-cov   - Run pytest with the CI coverage gate"
+	@echo "  make bdd        - Run outcome-oriented BDD specs"
+	@echo "  make pre-push   - Run local checks before pushing a PR branch"
+
+lint:
+	uv run ruff check
+
+typecheck:
+	uv run mypy src/waccy
+
+test:
+	uv run pytest
+
+test-cov:
+	uv run pytest --cov=src/waccy --cov-report=term-missing --cov-report=xml --cov-fail-under=80
+
+bdd:
+	uv run pytest tests/bdd -q -m "bdd or outcome"
+
+pre-push: lint typecheck bdd test-cov

--- a/README.md
+++ b/README.md
@@ -16,13 +16,16 @@ Unlike large enterprises with dedicated accounting teams, small businesses often
 
 ## Current Status
 
-WACCY is currently an early scaffold. The published packages expose the core interfaces, registry, data model shells, and first-party extension packages, but the end-to-end extraction and financial model workflow is not implemented yet.
+WACCY is an early package, but the v0.1.0 vertical slice now implements a fixture-first financial modeling path:
 
-The first useful vertical slice is tracked in [milestone v0.1.0](https://github.com/DecisionNerd/waccy/milestone/1) and [issue #15](https://github.com/DecisionNerd/waccy/issues/15). That release is focused on generating a three-sheet workbook from QBO/QuickBooks and EDGAR fixture data:
+* QBO/QuickBooks-shaped fixture extraction through `QuickBooksExtractor`
+* EDGAR/XBRL-shaped fixture extraction through `EdgarExtractor`
+* normalized, mapped, and validated financial datasets
+* deterministic source-to-WACCY account mapping with override support
+* three-statement model construction with reconciliation checks
+* XLSX export with the three required workbook sheets
 
-* Income Statement
-* Balance Sheet
-* Cash Flow Statement
+Live QuickBooks and EDGAR API clients are not implemented yet. The first milestone remains focused on hardening the fixture-first path into the [v0.1.0 release](https://github.com/DecisionNerd/waccy/milestone/1), tracked by [issue #15](https://github.com/DecisionNerd/waccy/issues/15).
 
 ## Quick Start
 
@@ -47,7 +50,7 @@ uv pip install waccy-edgar
 
 ### What Works Today
 
-The current package can discover installed extractor entry points and expose the public API skeleton:
+The current package can discover installed extractor entry points and build source-agnostic three-statement outputs from fixture data:
 
 ```python
 from waccy.extraction import ExtractorRegistry
@@ -57,14 +60,21 @@ available_sources = registry.list_extractors()
 print(f"Available data sources: {available_sources}")
 ```
 
-The following APIs are intentionally present but still raise `NotImplementedError` or return placeholders:
+Implemented v0.1.0 components include:
 
-* QuickBooks extraction
-* EDGAR extraction
-* account mapping and classification
+* fixture-first QBO and EDGAR extraction
+* standard account ontology and deterministic aliases
+* mapping, validation, reconciliation, and quality diagnostics
 * three-statement model building
 * spreadsheet export
-* validation and quality reporting
+* local and CI quality gates with BDD outcome specs
+
+Still planned:
+
+* live QuickBooks OAuth/API extraction
+* live EDGAR fetching and richer filing parsing
+* LLM-assisted classification and confidence scoring beyond placeholders
+* advanced model types such as DCF, LBO, M&A, and specialized industry models
 
 ## Planned Capabilities
 
@@ -123,68 +133,30 @@ The following APIs are intentionally present but still raise `NotImplementedErro
 * **Balance Checks**: Built-in reconciliation tables and error flags
 * **Scenario Tooling**: Data tables for sensitivity analysis, scenario toggles, goal seek integration
 
-## Planned Workflow
+## Fixture-First Workflow
 
-The target v0.1.0 workflow looks like this, but it is not runnable in the current package:
+The v0.1.0 workflow starts with fixture-shaped records. Live API configuration can be added later without changing the downstream modeling contract.
 
 ```python
-from waccy.extraction import ExtractorRegistry
-from waccy.classification import ClassificationEngine
 from waccy.modeling import ModelBuilder
-from waccy.core.ontology import StandardChartOfAccounts
+from waccy_quickbooks.extractor import QuickBooksExtractor
 
-# 1. Extract data from QuickBooks Online (handles messy, incomplete records)
-registry = ExtractorRegistry()
-extractor = registry.get_extractor("quickbooks")()
-credentials = {
-    "client_id": "your_client_id",
-    "client_secret": "your_client_secret",
-    "access_token": "your_access_token"
+fixture = {
+    "entity_name": "Example Co",
+    "periods": [
+        {"label": "2024", "start_date": "2024-01-01", "end_date": "2024-12-31"}
+    ],
+    "records": [
+        {"name": "Sales", "period": "2024", "amount": 1000, "statement": "income_statement"},
+        {"name": "Cost of Goods Sold", "period": "2024", "amount": 400, "statement": "income_statement"},
+        {"name": "Checking", "period": "2024", "amount": 100, "statement": "balance_sheet"},
+    ],
 }
-extractor.authenticate(credentials)
 
-extracted_data = extractor.extract({
-    "company_id": "123456789",
-    "date_range": ("2022-01-01", "2024-12-31"),
-    "include_transactions": True
-})
-
-# 2. Classify and map to standard accounts (with LLM enhancement for ambiguity)
-ontology = StandardChartOfAccounts()
-classification_engine = ClassificationEngine()
-
-for account in extracted_data.accounts:
-    mapped_account, confidence = classification_engine.classify_account(
-        source_account_name=account.name,
-        transaction_patterns=account.transaction_history,
-        context={"company_type": "SaaS", "industry": "Software"}
-    )
-    print(f"Mapped '{account.name}' to '{mapped_account.name}' (confidence: {confidence:.2f})")
-
-# 3. Build 3-statement integrated model
+extracted_data = QuickBooksExtractor().extract({"fixture": fixture})
 builder = ModelBuilder()
-model = builder.build_three_statement_model(
-    extracted_data=extracted_data,
-    forecast_periods=24
-)
-
-# 4. Generate DCF valuation
-dcf_model = builder.build_dcf_model(
-    three_statement_model=model,
-    wacc=0.10,
-    terminal_growth_rate=0.03,
-    exit_multiple=12.0
-)
-
-# 5. Export to spreadsheet output
+model = builder.build_three_statement_model(extracted_data)
 builder.export_to_sheets(model, output_path="financial_model.xlsx")
-builder.export_to_sheets(dcf_model, output_path="dcf_valuation.xlsx")
-
-# 6. Generate quality report
-quality_report = extracted_data.generate_quality_report()
-print(f"Data completeness: {quality_report.completeness:.2%}")
-print(f"Average mapping confidence: {quality_report.avg_confidence:.2f}")
-print(f"Issues flagged: {len(quality_report.issues)}")
 ```
 
 ## Target Output
@@ -198,7 +170,7 @@ print(f"Issues flagged: {len(quality_report.issues)}")
 
 ### v0.1.0 Workbook Structure
 
-```
+```text
 Financial Model.xlsx
 ├── Income Statement
 ├── Balance Sheet
@@ -211,22 +183,28 @@ Financial Model.xlsx
 
 **Primary Data Source** - The accounting system most commonly used by small businesses.
 
-Planned for v0.1.0:
+Implemented for v0.1.0:
 
 * Fixture-first extraction path for chart of accounts and statement data
-* Real-client path documented behind explicit credentials/configuration
 * Account normalization and source provenance
 * Skeptical treatment of source classifications with validation
+
+Planned after v0.1.0:
+
+* Real-client path documented behind explicit credentials/configuration
 
 ### SEC EDGAR
 
 **Pattern Learning & Reference Data** - High-quality financial data for learning and benchmarking.
 
-Planned for v0.1.0:
+Implemented for v0.1.0:
 
 * Fixture-first extraction path for public company statement data
 * Deterministic XBRL/concept mapping to WACCY accounts
 * Period normalization and source provenance
+
+Planned after v0.1.0:
+
 * A clear decision on whether EDGAR pattern learning ships in v0.1.0 or is deferred
 
 ### Extension Packages
@@ -397,7 +375,7 @@ Please read and follow our [Code of Conduct](CODE_OF_CONDUCT.md) to ensure a wel
 
 * **Current published core**: `waccy 0.0.2`
 * **Current published first-party extensions**: `waccy-quickbooks 0.1.0`, `waccy-edgar 0.0.2`
-* **Current implementation**: early scaffold with public interfaces and extension discovery
+* **Current implementation**: fixture-first v0.1.0 three-statement pipeline with public interfaces and extension discovery
 * **Next milestone**: [v0.1.0](https://github.com/DecisionNerd/waccy/milestone/1), focused on QBO/EDGAR three-sheet financial model generation
 
 Planned phases:
@@ -410,7 +388,7 @@ Planned phases:
 
 **Python Version**: 3.13+  
 **Package Manager**: [uv](https://github.com/astral-sh/uv)  
-**CI/CD**: GitHub Actions (coming soon)
+**CI/CD**: GitHub Actions, Codecov, and CodeRabbit
 
 ## 📄 License
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,17 @@ WACCY is an intelligent financial modeling platform designed to automatically ex
 
 Unlike large enterprises with dedicated accounting teams, small businesses often have inconsistent record-keeping, ambiguous account classifications, incomplete data, and limited financial infrastructure. WACCY transforms this raw, often chaotic business data into comprehensive, auditable, and decision-ready financial models that adhere to institutional-quality standards.
 
-## 🚀 Quick Start
+## Current Status
+
+WACCY is currently an early scaffold. The published packages expose the core interfaces, registry, data model shells, and first-party extension packages, but the end-to-end extraction and financial model workflow is not implemented yet.
+
+The first useful vertical slice is tracked in [milestone v0.1.0](https://github.com/DecisionNerd/waccy/milestone/1) and [issue #15](https://github.com/DecisionNerd/waccy/issues/15). That release is focused on generating a three-sheet workbook from QBO/QuickBooks and EDGAR fixture data:
+
+* Income Statement
+* Balance Sheet
+* Cash Flow Statement
+
+## Quick Start
 
 ### Installation
 
@@ -35,36 +45,28 @@ uv pip install waccy-quickbooks
 uv pip install waccy-edgar
 ```
 
-### Basic Usage
+### What Works Today
+
+The current package can discover installed extractor entry points and expose the public API skeleton:
 
 ```python
 from waccy.extraction import ExtractorRegistry
-from waccy.modeling import ModelBuilder
 
-# Discover available extractors
 registry = ExtractorRegistry()
 available_sources = registry.list_extractors()
 print(f"Available data sources: {available_sources}")
-
-# Extract data from QuickBooks Online
-quickbooks_extractor = registry.get_extractor("quickbooks")
-extracted_data = quickbooks_extractor().extract({
-    "company_id": "your_company_id",
-    "date_range": ("2023-01-01", "2024-12-31")
-})
-
-# Build a 3-statement financial model
-builder = ModelBuilder()
-model = builder.build_three_statement_model(
-    extracted_data=extracted_data,
-    forecast_periods=12
-)
-
-# Export to Google Sheets
-builder.export_to_sheets(model, output_path="financial_model.xlsx")
 ```
 
-## 📋 Core Features
+The following APIs are intentionally present but still raise `NotImplementedError` or return placeholders:
+
+* QuickBooks extraction
+* EDGAR extraction
+* account mapping and classification
+* three-statement model building
+* spreadsheet export
+* validation and quality reporting
+
+## Planned Capabilities
 
 ### 🤖 **AI-Powered Data Extraction & Classification**
 
@@ -115,13 +117,15 @@ builder.export_to_sheets(model, output_path="financial_model.xlsx")
 
 ### 📝 **Professional Model Outputs**
 
-* **Google Sheets Export**: Production-ready spreadsheet models with proper formatting
+* **Spreadsheet Export**: Production-ready workbook models with proper formatting
 * **Professional Architecture**: Modular tab structures, consistent time axis, clear sign conventions
 * **Color Conventions**: Inputs in blue, calculations in black, outputs in green
 * **Balance Checks**: Built-in reconciliation tables and error flags
 * **Scenario Tooling**: Data tables for sensitivity analysis, scenario toggles, goal seek integration
 
-## 🔄 Complete Workflow
+## Planned Workflow
+
+The target v0.1.0 workflow looks like this, but it is not runnable in the current package:
 
 ```python
 from waccy.extraction import ExtractorRegistry
@@ -172,7 +176,7 @@ dcf_model = builder.build_dcf_model(
     exit_multiple=12.0
 )
 
-# 5. Export to Google Sheets
+# 5. Export to spreadsheet output
 builder.export_to_sheets(model, output_path="financial_model.xlsx")
 builder.export_to_sheets(dcf_model, output_path="dcf_valuation.xlsx")
 
@@ -183,7 +187,7 @@ print(f"Average mapping confidence: {quality_report.avg_confidence:.2f}")
 print(f"Issues flagged: {len(quality_report.issues)}")
 ```
 
-## 📊 Example Output
+## Target Output
 
 ### Standardized Account Mapping
 
@@ -192,32 +196,13 @@ print(f"Issues flagged: {len(quality_report.issues)}")
 **Confidence**: 0.95  
 **Validation**: ✅ Transaction patterns match revenue recognition
 
-### 3-Statement Model Structure
+### v0.1.0 Workbook Structure
 
 ```
 Financial Model.xlsx
-├── Assumptions
-│   ├── Revenue Drivers
-│   ├── Cost Assumptions
-│   └── Working Capital
 ├── Income Statement
-│   ├── Historical (3 years)
-│   └── Forecast (2 years)
 ├── Balance Sheet
-│   ├── Assets (Current & Non-Current)
-│   ├── Liabilities (Current & Non-Current)
-│   └── Equity
-├── Cash Flow Statement
-│   ├── Operating Activities
-│   ├── Investing Activities
-│   └── Financing Activities
-├── Supporting Schedules
-│   ├── Working Capital Detail
-│   ├── Debt Schedule
-│   └── Depreciation
-└── Checks & Reconciliations
-    ├── Balance Checks
-    └── Quality Metrics
+└── Cash Flow Statement
 ```
 
 ## 🔗 Core Data Sources
@@ -226,25 +211,27 @@ Financial Model.xlsx
 
 **Primary Data Source** - The accounting system most commonly used by small businesses.
 
-* Direct API integration for chart of accounts, general ledger, and financial statements
-* Intelligent handling of ambiguous, inconsistently-named accounts
-* Transaction-level detail extraction
-* Vendor and customer data integration
+Planned for v0.1.0:
+
+* Fixture-first extraction path for chart of accounts and statement data
+* Real-client path documented behind explicit credentials/configuration
+* Account normalization and source provenance
 * Skeptical treatment of source classifications with validation
 
 ### SEC EDGAR
 
 **Pattern Learning & Reference Data** - High-quality financial data for learning and benchmarking.
 
-* Automated parsing of 10-K, 10-Q, 8-K filings
-* Proxy statement and registration statement processing
-* Pattern extraction for proper financial classification
-* Learning causal chains from professional financial reports
-* Application of learned patterns to small business data
+Planned for v0.1.0:
+
+* Fixture-first extraction path for public company statement data
+* Deterministic XBRL/concept mapping to WACCY accounts
+* Period normalization and source provenance
+* A clear decision on whether EDGAR pattern learning ships in v0.1.0 or is deferred
 
 ### Extension Packages
 
-Additional data sources available as modular extensions:
+Additional data sources are planned as modular extensions, but they are not included in the current repository:
 
 * `waccy-google` - Google Drive and Gmail integration
 * `waccy-xero` - Xero accounting system
@@ -275,7 +262,7 @@ waccy/
 │       ├── modeling/
 │       │   ├── builder.py           # Model construction
 │       │   ├── templates.py         # Model templates
-│       │   └── exporters.py         # Google Sheets export
+│       │   └── exporters.py         # Spreadsheet export
 │       └── utils/
 │           ├── dates.py
 │           ├── formatting.py
@@ -297,9 +284,12 @@ waccy/
 │   └── publish-extension.py        # Publish extension packages
 ├── docs/
 │   ├── 0-MISSION.md
-│   ├── 1-ARCHITECTURE.md
-│   ├── 2-EXPERIENCE.md
-│   └── skills_models.md
+│   ├── 1-EXPERIENCE.md
+│   ├── 2-REQUIREMENTS.md
+│   ├── 3-ARCHITECTURE.md
+│   ├── assets/
+│   ├── examples/
+│   └── references/
 └── pyproject.toml                   # Core package configuration
 ```
 
@@ -339,9 +329,9 @@ uv run mypy src/waccy
 ## 📚 Documentation
 
 * **[Mission Statement](docs/0-MISSION.md)** - Project goals, philosophy, and roadmap
-* **[Architecture](docs/1-ARCHITECTURE.md)** - Technical architecture and design principles
-* **[Experience Guide](docs/2-EXPERIENCE.md)** - User experience and workflows
-* **[Skills & Models](docs/skills_models.md)** - Financial modeling capabilities
+* **[Experience](docs/1-EXPERIENCE.md)** - Target user workflows and release experience
+* **[Requirements](docs/2-REQUIREMENTS.md)** - Financial modeling requirements and capabilities
+* **[Architecture](docs/3-ARCHITECTURE.md)** - Technical architecture and design principles
 
 ## 🏛️ Design Principles
 
@@ -395,23 +385,29 @@ Want to add a new data source? Create an extension package:
 1. Create a new package: `waccy-yourdatasource`
 2. Implement the `Extractor` interface from `waccy.extraction.base`
 3. Register your extension via entry points
-4. Follow the [Extension Development Guide](docs/1-ARCHITECTURE.md#extension-development-guide)
+4. Follow the [Extension Development Guide](docs/3-ARCHITECTURE.md#extension-development-guide)
 
-See our [Architecture Documentation](docs/1-ARCHITECTURE.md) for detailed extension development guidelines.
+See our [Architecture Documentation](docs/3-ARCHITECTURE.md) for detailed extension development guidelines.
 
 ### Code of Conduct
 
 Please read and follow our [Code of Conduct](CODE_OF_CONDUCT.md) to ensure a welcoming environment for all contributors.
 
-## 📈 Project Status
+## Project Status
 
-* **Phase 1**: 📋 Planned - Core foundation and 3-statement models
-* **Phase 2**: 📋 Planned - Public market data and pattern learning (EDGAR)
-* **Phase 3**: 📋 Planned - Advanced valuation models (DCF, M&A, LBO)
-* **Phase 4**: 📋 Planned - Specialized model types (SaaS, REIT, project finance)
-* **Phase 5**: 📋 Planned - Advanced analysis and decision support
+* **Current published core**: `waccy 0.0.2`
+* **Current published first-party extensions**: `waccy-quickbooks 0.1.0`, `waccy-edgar 0.0.2`
+* **Current implementation**: early scaffold with public interfaces and extension discovery
+* **Next milestone**: [v0.1.0](https://github.com/DecisionNerd/waccy/milestone/1), focused on QBO/EDGAR three-sheet financial model generation
 
-**Current Status**: Early development - Architecture and core platform design  
+Planned phases:
+
+* **Phase 1**: Core foundation and three-statement models
+* **Phase 2**: Public market data and pattern learning
+* **Phase 3**: Advanced valuation models
+* **Phase 4**: Specialized model types
+* **Phase 5**: Advanced analysis and decision support
+
 **Python Version**: 3.13+  
 **Package Manager**: [uv](https://github.com/astral-sh/uv)  
 **CI/CD**: GitHub Actions (coming soon)

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,26 @@
+coverage:
+  precision: 2
+  round: down
+  range: "80...100"
+  status:
+    project:
+      default:
+        target: 80%
+        threshold: 2%
+        if_ci_failed: error
+    patch:
+      default:
+        target: 80%
+        threshold: 5%
+        if_ci_failed: error
+
+comment:
+  layout: "reach,diff,flags,tree"
+  behavior: default
+  require_changes: true
+
+ignore:
+  - "tests/**"
+  - "docs/**"
+  - "scripts/**"
+  - "extensions/**"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,16 +1,16 @@
 coverage:
   precision: 2
   round: down
-  range: "80...100"
+  range: "90...100"
   status:
     project:
       default:
-        target: 80%
+        target: 90%
         threshold: 2%
         if_ci_failed: error
     patch:
       default:
-        target: 80%
+        target: 90%
         threshold: 5%
         if_ci_failed: error
 

--- a/docs/0-MISSION.md
+++ b/docs/0-MISSION.md
@@ -1,360 +1,54 @@
-# WACCY MISSION
+# WACCY Mission
 
-## Core Mission
+WACCY exists to make institutional-quality financial modeling accessible to small businesses and the people who advise, invest in, lend to, or operate them.
 
-WACCY is an intelligent financial modeling platform designed to automatically extract, parse, classify, and synthesize business data from diverse sources to generate sophisticated, production-grade financial models and operating analyses. **The platform's primary focus is on small businesses—from sole proprietorships to growing companies—that struggle with messy, incomplete, and poorly-maintained financial records.** While WACCY is not intentionally designed to exclude large enterprises, the reality is that small businesses face unique challenges: inconsistent record-keeping, ambiguous account classifications, incomplete data, and limited financial infrastructure. WACCY transforms this raw, often chaotic business data into comprehensive, auditable, and decision-ready financial models that adhere to institutional-quality standards.
+Small businesses often have the same strategic questions as larger companies:
 
-The fundamental challenge WACCY addresses is the ambiguity and incompleteness that poor record-keeping creates in small business financial data. Unlike large enterprises with dedicated accounting teams and rigorous financial controls, small businesses often have:
-- Inconsistent account naming and categorization
-- Missing or incomplete transaction records
-- Mixed personal and business expenses
-- Unclear revenue recognition and expense classification
-- Limited historical data and documentation
-- Manual processes prone to errors and omissions
+- What is this business worth?
+- What is actually driving cash flow?
+- How risky is growth, debt, or a transaction?
+- Which financial records can be trusted, and which need review?
+- How does this business compare with better-documented peers?
 
-WACCY leverages large language models (LLMs) and foundation models as intelligent agents for parsing, classification, and data extraction, while maintaining a preference for deterministic functions and rule-based models wherever possible to ensure accuracy, reproducibility, and auditability. The platform's architecture prioritizes transparency, allowing users to understand the provenance of every data point and the logic behind every calculation, even when working with incomplete or ambiguous source data.
+But their records are usually messier. QuickBooks accounts may be inconsistent, transactions may be misclassified, historical data may be incomplete, and personal, operational, and financing activity may be blended together. WACCY's mission is to turn that imperfect source data into auditable, decision-ready financial models without pretending the data is cleaner than it is.
 
-## Data Sources and Integration Strategy
+## Core Thesis
 
-### Core Data Sources
+Financial modeling quality depends on classification quality. A beautiful model built on misclassified accounts is still wrong.
 
-WACCY maintains a simple, focused core with two primary data source integrations, each serving a distinct purpose in addressing the small business financial modeling challenge:
+WACCY therefore starts with a standardized financial ontology, maps all source data into that ontology, reports confidence and data quality, and only then builds financial statements and models. The platform should be skeptical of source classifications, transparent about assumptions, and explicit about gaps.
 
-- **QuickBooks Online (QBO)**: Direct API integration to extract chart of accounts, general ledger entries, financial statements (income statement, balance sheet, cash flow statement), transaction-level detail, vendor and customer data, and supporting schedules. **QBO is the primary data source because it is the accounting system most commonly used by small businesses.** While QBO provides structured data through its API, the reality is that small businesses often maintain their QuickBooks records inconsistently, with ambiguous account names, misclassified transactions, and incomplete entries. WACCY must intelligently parse and normalize this messy data, treating source classifications with appropriate skepticism and mapping everything to the standardized WACCY chart of accounts.
+## Who It Serves
 
-- **SEC EDGAR**: Automated parsing of 10-K, 10-Q, 8-K filings, proxy statements, and registration statements for publicly traded companies. **EDGAR serves a dual purpose**: First, it provides an easy source of truth—high-quality, professionally-prepared financial data from the largest businesses, where tabular financial data is associated with natural language reports written by accounting and finance professionals. Second, and more importantly, EDGAR provides access to thousands and thousands of cases that demonstrate how financial events, transactions, and business activities are properly classified, reported, and explained. This corpus of high-quality examples enables WACCY to learn patterns and causal chains—how revenue recognition works, how expenses are categorized, how working capital moves, how transactions flow through financial statements—that can then be applied to infer proper classification and modeling approaches for similar situations in small businesses, even when their records are incomplete or ambiguous. By studying how professionals at large companies handle complex financial scenarios, WACCY can apply those same principles to help sole proprietorships and small businesses achieve similar analytical rigor despite their messy source data.
+WACCY is designed primarily for:
 
-### Modular Data Source Extensions
+- advisors, accountants, investors, lenders, and operators working with small businesses
+- founders and owners who need clearer financial visibility
+- developers building financial-modeling workflows on top of messy business data
 
-All other data sources are implemented as modular, extensible packages that plug into the core WACCY platform. This design philosophy ensures:
+The platform is not designed to exclude larger companies, but its center of gravity is the small-business world: companies that need rigorous analysis but often lack rigorous financial infrastructure.
 
-- **Simplicity**: The core platform remains focused and maintainable
-- **Extensibility**: New data sources can be added without modifying core functionality
-- **Flexibility**: Users install only the data source integrations they need
-- **Community Development**: Third-party developers can create and maintain data source packages
+## How WACCY Should Work
 
-Examples of modular data source packages (not included in core):
-- **Google Drive / Gmail**: Document parsing and email extraction for unstructured data
-- **Banking and payment systems**: Transaction-level data from bank feeds and payment processors
-- **CRM and sales systems**: Pipeline data, customer contracts, and revenue recognition details
-- **HR and payroll systems**: Headcount data and compensation structures
-- **ERP and inventory systems**: Supply chain data and operational metrics
-- **Market data APIs**: Real-time pricing, trading multiples, and economic indicators
-- **Other accounting systems**: Xero, Sage, NetSuite, and other accounting platform integrations
+WACCY should prefer deterministic, reproducible logic wherever possible:
 
-The core platform provides a standardized interface and ontology that all data source packages must conform to, ensuring consistent data classification and model construction regardless of the source.
+- parse structured data with structured parsers
+- map known accounts and concepts with explicit rules
+- calculate financial statements with transparent formulas
+- validate outputs with reconciliation checks
 
-### Data Quality and Parsing Philosophy
-
-WACCY employs a hybrid approach to data extraction and classification, designed specifically to handle the messy, incomplete data typical of small businesses:
-
-1. **Deterministic First (Core)**: The core platform uses deterministic parsing functions and rule-based extraction where data structures are known:
-   - **QuickBooks Online**: While QBO provides structured API access, the platform does not blindly trust source account classifications. Instead, it uses deterministic mapping combined with intelligent validation to map messy, inconsistently-named accounts to the WACCY standard chart of accounts. The platform recognizes that small businesses often have poorly-organized charts of accounts and treats source classifications with appropriate skepticism.
-   - **SEC EDGAR**: Standardized filing formats enable deterministic parsing of financial statements and disclosures. This high-quality data serves as both a reference source and a training corpus for understanding proper financial classification and reporting patterns.
-
-2. **LLM-Enhanced Parsing for Ambiguity Resolution**: The platform leverages foundation models to handle the ambiguity and incompleteness inherent in small business data:
-   - **Account Classification**: When source account names are ambiguous or don't clearly map to standard categories, LLMs analyze transaction patterns, account relationships, and contextual clues to infer proper classification
-   - **Missing Data Inference**: When data is incomplete, the platform uses patterns learned from EDGAR filings and other high-quality sources to infer what might be missing and how to handle gaps
-   - **Causal Chain Recognition**: By studying thousands of EDGAR filings, the platform learns how financial events cascade through statements (e.g., how a lease affects both income statement and balance sheet), enabling it to identify and correct similar patterns in messy small business data
-   - **Terminology Normalization**: Recognizing equivalent concepts across different naming conventions (e.g., "revenue," "sales," "income") and mapping them to standardized accounts
-   - **Relationship Inference**: Linking related data points (e.g., connecting a lease agreement mentioned in notes to balance sheet lease liabilities) even when explicit connections are missing
-
-3. **Validation and Reconciliation**: All extracted data—whether from core sources or modular extensions—undergoes validation checks, cross-referencing between sources, and reconciliation to ensure consistency. The platform flags discrepancies, missing data, ambiguous classifications, and potential errors for user review. All data sources, regardless of origin or quality, must map to the standardized WACCY chart of accounts, enabling quality quantification even when source data is messy.
-
-### Data Classification Ontology and Standardized Chart of Accounts
-
-A fundamental principle of WACCY is the establishment and maintenance of a standardized classification ontology that serves as the authoritative baseline for all financial data mapping and model construction. This ontology is critical because the quality and comparability of all downstream analysis—from basic financial statements to sophisticated valuation models—depends entirely on consistent, accurate classification of financial data.
-
-**The WACCY Standardized Chart of Accounts**
-
-WACCY maintains a comprehensive, standardized chart of accounts that serves as the canonical reference for all financial data classification. This standard chart of accounts is designed to:
-
-- **Ensure Consistency**: All businesses, regardless of their source system's account structure, are mapped to the same standardized accounts, enabling consistent analysis, benchmarking, and comparison
-- **Support All Model Types**: The standard chart of accounts is structured to support the full range of model types—from basic 3-statement models to complex LBO and M&A analyses—with proper account hierarchies and classifications
-- **Enable Quality Quantification**: By standardizing classifications, WACCY can quantify the quality and completeness of data extraction, mapping accuracy, and model outputs
-- **Facilitate Cross-Company Analysis**: Standardized accounts enable meaningful peer comparisons, industry benchmarking, and transaction comparables analysis
-
-The WACCY standard chart of accounts includes:
-- **Income Statement Accounts**: Revenue (by type and segment), COGS (by component), operating expenses (by functional area), non-operating items, taxes, and non-recurring items
-- **Balance Sheet Accounts**: Current and non-current assets (with working capital detail), current and non-current liabilities (including debt detail), equity components, and off-balance sheet items
-- **Cash Flow Accounts**: Operating, investing, and financing activities with detailed line items
-- **Supporting Schedules**: Debt schedules, equity schedules, working capital detail, and other supporting analyses
-
-**Skeptical Treatment of Input Classifications**
-
-WACCY treats all input chart of accounts and classifications from source systems with appropriate skepticism. Rather than blindly accepting account names, categories, and classifications from QuickBooks, Google Drive documents, or other sources, the platform:
-
-- **Normalizes All Input**: Every account from source systems is mapped to the WACCY standard through intelligent classification, not direct import
-- **Validates Classifications**: LLM-enhanced classification validates that source account names and categories align with their actual usage and transaction patterns
-- **Flags Anomalies**: Accounts that don't map cleanly to the standard, have ambiguous classifications, or show inconsistent usage patterns are flagged for review
-- **Learns from Context**: Classification considers not just account names but transaction patterns, relationships to other accounts, and contextual clues from financial statements
-
-This skeptical approach is essential because:
-- **Source Systems Are Inconsistent**: Businesses use wildly different account naming conventions, categorization schemes, and organizational structures
-- **Errors Are Common**: Manual account setup, copy-paste errors, and evolving business needs lead to misclassified accounts in source systems
-- **Quality Depends on Accuracy**: A single misclassified account can cascade through all downstream analysis, making it impossible to quantify model quality
-- **Comparability Requires Standardization**: Meaningful analysis across companies, time periods, or scenarios requires consistent classification
-
-**Industry-Specific Customization from Standard**
-
-While the WACCY standard chart of accounts serves as the universal baseline, the platform supports industry-specific extensions and customizations that build upon—rather than replace—the standard:
-
-- **Industry Templates**: Pre-configured extensions for SaaS, manufacturing, retail, real estate, professional services, and other industries that add industry-specific accounts while maintaining the core standard
-- **Custom Account Hierarchies**: Businesses can add custom accounts and sub-accounts for industry-specific needs (e.g., "Deferred Revenue - Annual Subscriptions" for SaaS companies) that map to standard parent categories
-- **Flexible Mapping**: The platform maintains the mapping between custom/industry-specific accounts and the standard, ensuring that custom accounts enhance rather than fragment the standard ontology
-- **Backward Compatibility**: All customizations maintain compatibility with the standard, ensuring that industry-specific models can still be compared and analyzed using standard metrics
-
-**Quality Quantification Through Standardization**
-
-The standardized ontology enables WACCY to quantify the quality of data extraction, classification, and model outputs:
-
-- **Mapping Confidence Scores**: Each account mapping receives a confidence score based on the clarity of the mapping, consistency of usage, and validation against transaction patterns
-- **Completeness Metrics**: The platform can measure how completely a business's financial data maps to the standard, identifying gaps and missing information
-- **Classification Accuracy**: By comparing source classifications to validated mappings, WACCY can assess and report on classification accuracy
-- **Model Quality Indicators**: Standardized inputs enable quality metrics for model outputs—balance checks, ratio reasonableness, trend consistency, and peer comparability
-- **Audit Trails**: Every classification decision is logged, allowing users to understand how source accounts were mapped to the standard and review any questionable mappings
-
-This quality quantification is only possible because of the standardized ontology. Without a consistent baseline, it becomes impossible to determine whether a model's outputs are accurate, complete, or comparable—rendering sophisticated analysis meaningless regardless of the sophistication of the modeling techniques employed.
-
-## Financial Modeling Capabilities
-
-WACCY generates institutional-quality financial models that encompass the full spectrum of financial analysis, from basic operating models to sophisticated valuation and transaction analysis. The platform adheres to professional standards for model architecture, formula design, and presentation.
-
-### Model Engineering and Spreadsheet Craft
-
-All models output to multiple formats, with Google Sheets serving as the primary spreadsheet platform. Models are constructed with:
-
-- **Model Architecture**: Modular tab structures that separate inputs/assumptions from calculations and outputs, consistent time axis across all statements, clear sign conventions, and isolation of hardcoded values to designated assumption areas
-- **Formatting Standards**: Professional color conventions (inputs in blue, calculations in black, outputs in green), consistent unit handling (thousands/millions), robust date handling, and print-ready layouts
-- **Formula Design**: Robust cell links that avoid fragile OFFSET dependencies, transparent logic that can be easily audited, and minimization of circular references with controlled iterative calculation where necessary
-- **Speed and Scale**: Efficient formula construction, optimized calculation settings, iterative calculation controls, and performance hygiene for models handling large datasets
-- **Auditability**: Built-in check rows, balance checks, roll-forward reconciliations, error flags, reconciliation tables, and support for tracing precedents and dependents
-- **Scenario Tooling**: Data tables for sensitivity analysis, scenario toggles, switch cases for multiple scenarios, goal seek and solver integration, sensitivity matrices, and tornado charts for risk analysis
-- **Advanced Spreadsheet Tools**: Integration with pivot tables, named ranges, dynamic arrays (ARRAYFORMULA/LAMBDA in Google Sheets), query functions, and Apps Script automation capabilities
-
-### Accounting and Financial Statement Analysis
-
-Models incorporate deep understanding of accounting mechanics:
-
-- **Income Statement Mechanics**: Proper revenue recognition principles, accurate COGS vs operating expense classification, margin stack analysis, stock-based compensation handling, and identification of non-recurring items
-- **Balance Sheet Mechanics**: Working capital account modeling (accounts receivable, inventory, accounts payable), deferred revenue recognition, accrued expense tracking, proper debt vs equity classification, and lease accounting (ASC 842) awareness
-- **Cash Flow Mechanics**: Indirect method cash flow construction, non-cash add-backs, net working capital bridge analysis, proper capex vs opex classification, and accurate financing vs investing activity categorization
-- **Quality of Earnings**: Normalization adjustments to identify run-rate performance, separation of one-time costs and restructuring charges, foreign exchange impact analysis, and adjustments for non-operating items
-- **Ratio and Returns Analysis**: Calculation of ROIC, ROE, ROA, DuPont analysis, margin and asset turnover metrics, leverage ratios, coverage ratios, and liquidity measures
-- **Credit Analysis Lens**: Leverage ratio calculations, fixed-charge coverage analysis, covenant compliance modeling, and debt capacity assessment frameworks
-
-### Forecasting Methods (Driver-Based, Not Assumption-Based)
-
-Models employ sophisticated forecasting methodologies that build from operational drivers rather than top-down assumptions:
-
-- **Revenue Builds**: Price × volume models, units × ARPU (average revenue per user) frameworks, cohort and retention models for SaaS businesses, pipeline conversion models, and capacity-based revenue projections
-- **Cost Builds**: Variable vs fixed cost frameworks, detailed headcount models with compensation structures, gross margin driver analysis, operating expense builds by functional area, and inflation indexing
-- **Working Capital Modeling**: Days sales outstanding (DSO), days inventory outstanding (DIO), days payable outstanding (DPO) analysis, working capital as percentage of revenue, seasonality adjustments, inventory turnover analysis, and deferred revenue dynamics
-- **Capex & Depreciation**: Capital expenditure modeling by category, asset life assumptions, depreciation waterfall construction, and capitalized software development cost handling
-- **Debt & Interest Modeling**: Revolver mechanics with availability calculations, fixed and floating rate modeling, spread analysis, detailed amortization schedules, and cash sweep waterfall construction
-- **Equity & Share Modeling**: Basic and diluted share count calculations, treasury stock method for options, convertible security handling, RSU and option modeling, and share buyback/issuance tracking
-- **Tax Modeling**: Effective tax rate vs statutory rate analysis, deferred tax assets (DTAs) and deferred tax liabilities (DTLs) modeling, NOL (net operating loss) utilization tracking, and interest limitation (Section 163(j)) awareness
-- **Segment and Geography Analysis**: Segment-level KPI tracking, mix shift analysis, foreign exchange translation handling, and margin difference analysis by segment
-
-### Core Valuation Methods
-
-WACCY generates comprehensive valuation analyses using industry-standard methodologies:
-
-- **DCF (Discounted Cash Flow) Intrinsic Valuation**
-  - Unlevered free cash flow construction (NOPAT + D&A − Capex − ΔNWC)
-  - Proper discounting mechanics including stub period handling and mid-year convention
-  - Terminal value calculation using both perpetuity growth and exit multiple methods
-  - Enterprise value to equity value bridge accounting for net debt, minority interests, investments, and preferred equity
-  - WACC (weighted average cost of capital) build including cost of equity (CAPM), cost of debt, and target capital structure assumptions
-
-- **Relative Valuation**
-  - Trading comparables analysis with peer selection, financial statement spreading, metric normalization, and calculation of EV/Revenue, EV/EBITDA, P/E, and sector-specific multiples
-  - Transaction comparables analysis using precedent M&A deals, implied multiple calculation, control premium analysis, and deal-specific adjustments
-
-- **Additional Valuation Frameworks**
-  - Sum-of-the-parts (SOTP) valuation for diversified businesses
-  - Implied multiple triangulation across methodologies
-  - Football field valuation summaries
-  - APV (Adjusted Present Value) for clarity on leverage and tax shield effects
-  - Residual income and economic profit frameworks where applicable
-
-### M&A and Pro Forma Analysis Methods
-
-For transaction analysis, models include:
-
-- **Accretion/Dilution Analysis**: Pro forma EPS impact calculation, synergy timing and phasing, financing mix sensitivity analysis
-- **Sources & Uses of Funds**: Cash, stock, and debt mix analysis, transaction fees, refinancing assumptions, and rollover equity calculations
-- **Purchase Accounting / PPA (Purchase Price Allocation)**: Goodwill calculation, intangible asset identification and valuation, step-up adjustments, deferred tax impacts, and amortization schedule construction
-- **Deal Structure Modeling**: Fixed vs floating exchange ratio analysis, collar mechanisms, contingent consideration and earn-out modeling
-- **Synergy Modeling**: Cost synergy and revenue synergy identification, phasing assumptions, one-time integration cost tracking, and dis-synergy recognition
-- **Contribution Analysis**: Relative ownership calculations, value transfer analysis, and synergy split logic
-- **Pro Forma Financial Statements**: Combined income statement, balance sheet, and cash flow statement with transaction adjustments and financing effects
-
-### LBO and Private Equity Modeling Methods
-
-For leveraged buyout and private equity analysis:
-
-- **Returns Math**: IRR (internal rate of return), MOIC (multiple on invested capital), and cash-on-cash return calculations
-- **Capital Structure Modeling**: Senior debt, mezzanine debt, high-yield notes, PIK (payment-in-kind) instruments, revolver facilities, management rollover equity, and preferred equity structures
-- **Debt Schedule Construction**: Mandatory amortization schedules, cash sweep mechanics, refinancing assumptions, and call protection awareness for high-yield debt
-- **Interest Modeling**: Fixed vs floating rate handling, SOFR/LIBOR base rate + spread calculations, blended interest rate determination, and average balance conventions
-- **Tax Effect Analysis**: Interest tax shield calculations, NOL utilization, interest limitation awareness, and cash tax vs book tax reconciliation
-- **Exit Analysis**: Exit multiple scenarios, IPO vs strategic sale vs secondary sale analysis, deleveraging effects, and dividend recapitalization modeling
-- **Sensitivity Analysis**: Comprehensive sensitivity grids analyzing entry multiple, exit multiple, leverage levels, EBITDA growth, margin expansion, hold period, and interest rate environment impacts
-
-### Data Sourcing, Standardization, and "Spreading"
-
-The platform handles the complex work of data normalization and standardization:
-
-- **Core Source Integration**: Automated extraction from SEC EDGAR filings (10-K, 10-Q, 8-K, proxy statements) for public company data. Additional sources (earnings releases, investor presentations, call transcripts) can be provided through modular extensions.
-- **Normalization and Adjustments**: GAAP to non-GAAP reconciliation, run-rate adjustments, segment restatement handling, and pro forma adjustment identification
-- **Consistency Work**: Calendarization of fiscal periods to calendar quarters, LTM (last twelve months) building, pro forma adjustment application, and currency and foreign exchange handling
-- **Market Data Integration**: Market data integration (share price, market capitalization, debt pricing, yield curves) can be provided through modular extension packages, ensuring the core platform remains focused
-
-### Presentation and Decision-Support Outputs
-
-Models generate professional outputs designed for decision-making:
-
-- **Valuation Summaries**: Valuation ranges with quartiles and medians, implied valuation calculations, and key assumption callouts
-- **Charts & Tables**: Comparables tables, sensitivity analysis tables, bridge charts (enterprise value to equity value), debt waterfall diagrams, and return bridge analyses
-- **Narrative Framing**: Investment highlights, key risk identification, diligence question generation, and KPI dashboard construction
-
-## Model Types and Deliverables
-
-WACCY generates a comprehensive suite of financial model types:
-
-- **3-Statement Integrated Operating Model**: The foundational model type, integrating income statement, balance sheet, and cash flow statement with full balancing and reconciliation
-- **DCF Valuation Model**: Discounted cash flow analysis with detailed free cash flow construction, terminal value analysis, and WACC calculation
-- **Trading Comparables Model**: Peer company analysis with multiple calculation and benchmarking
-- **Transaction Comparables Model**: Precedent M&A transaction analysis
-- **Merger Model**: Accretion/dilution analysis combined with purchase accounting
-- **LBO Model**: Leveraged buyout analysis with returns calculation and debt schedule modeling
-- **SOTP / Break-Up Valuation Model**: Sum-of-the-parts valuation for diversified businesses
-- **Cap Table & Dilution Model**: Equity ownership tracking with options, convertibles, and dilution analysis
-- **Credit / Covenant Compliance Model**: Debt covenant tracking and compliance analysis
-- **Budget vs Actual / Forecast (FP&A) Model**: Financial planning and analysis with variance analysis
-- **Project Finance / Infrastructure Model**: Cash waterfall construction with DSCR (debt service coverage ratio) and LLCR (loan life coverage ratio) analysis
-- **Real Estate (REIT) / Property Cash Flow Model**: Property-level cash flow and valuation analysis
-- **SaaS Cohort + Unit Economics Model**: Subscription business analysis with cohort retention and unit economics
-- **Carve-Out / Spin / Restructuring Model**: Corporate restructuring and separation analysis
-
-## Phased Development Approach
-
-### Phase One: Core Foundation and 3-Statement Models
-
-**Objective**: Establish the foundational platform with core data source integration, standardized ontology, and basic operating model generation—specifically designed to handle the messy, incomplete data typical of small businesses using QuickBooks Online.
-
-**Deliverables**:
-- Core platform architecture with modular data source interface
-- QuickBooks Online API integration (core data source) with intelligent handling of ambiguous, inconsistently-named accounts
-- WACCY standardized chart of accounts definition and implementation
-- Intelligent mapping of messy source chart of accounts to WACCY standard (with LLM-enhanced classification and validation to handle poor record-keeping)
-- Automated 3-statement financial model generation (income statement, balance sheet, cash flow statement) using standardized accounts, even when source data is incomplete
-- Basic model architecture with proper balancing, reconciliation, and audit trails
-- Standard formatting and presentation outputs
-- Mapping confidence scoring and classification quality metrics to quantify data quality despite source ambiguity
-- Plugin architecture for modular data source extensions
-
-**Technical Focus**: Reliability, accuracy, and auditability of data extraction from messy small business records, standardized classification ontology that handles ambiguity, and model construction that works with incomplete data. Establishing the foundation for quality-quantifiable analysis through consistent data classification and a simple, extensible architecture that doesn't require perfect source data.
-
-### Phase Two: Public Market Data and Pattern Learning
-
-**Objective**: Integrate SEC EDGAR filings as both a source of high-quality reference data and a training corpus for learning financial classification patterns that can be applied to messy small business data.
-
-**Deliverables**:
-- SEC EDGAR integration (core data source) for public company data extraction
-  - 10-K, 10-Q, 8-K automated parsing
-  - Proxy statement analysis
-  - Registration statement processing
-- Pattern learning framework that extracts causal chains and classification patterns from thousands of EDGAR filings
-- Application of learned patterns to infer proper classification and modeling approaches for similar situations in small businesses
-- Trading comparables model generation
-- Transaction comparables model construction
-- Data normalization and calendarization frameworks
-- Cross-company analysis capabilities
-
-**Technical Focus**: Large-scale data normalization, calendarization, pattern extraction from high-quality professional financial reports, and applying those patterns to improve classification of messy small business data. Using EDGAR's combination of tabular data and natural language reports to understand how professionals handle complex financial scenarios.
-
-### Phase Three: Advanced Valuation Models
-
-**Objective**: Enable comprehensive valuation analysis through sophisticated model types.
-
-**Deliverables**:
-- DCF valuation model automation
-- M&A and pro forma analysis models
-- LBO model generation
-- Advanced valuation framework integration
-- Sensitivity and scenario analysis tooling
-
-**Technical Focus**: Sophisticated model type generation and valuation methodology implementation.
-
-### Phase Four: Specialized Model Types
-
-**Objective**: Expand to specialized model types for specific use cases and industries.
-
-**Deliverables**:
-- SaaS cohort and unit economics models
-- Real estate and REIT models
-- Project finance and infrastructure models
-- Cap table and dilution analysis
-- Credit and covenant compliance models
-- Industry-specific template libraries (as modular extensions)
-
-**Technical Focus**: Domain expertise integration and specialized calculation frameworks.
-
-### Phase Five: Advanced Analysis and Decision Support
-
-**Objective**: Enable sophisticated scenario modeling and strategic decision support.
-
-**Deliverables**:
-- Multi-scenario model generation
-- Sensitivity analysis automation
-- Monte Carlo simulation capabilities
-- Strategic planning model integration
-- What-if analysis tools
-- Automated scenario comparison and reporting
-- Intelligent data synthesis from fragmented sources
-- Model generation from incomplete or inconsistent data with confidence scoring
-
-**Technical Focus**: Advanced modeling capabilities, decision-support tooling, and robustness in handling data quality issues.
-
-### Modular Extension Development
-
-Throughout all phases, the platform architecture supports modular data source extensions developed as separate packages. These extensions can be developed by the core team or by the community, and include:
-
-- Document parsing packages (Google Drive, PDFs, spreadsheets)
-- Communication extraction packages (Gmail, Slack, etc.)
-- Banking and payment system integrations
-- CRM and sales system integrations
-- HR and payroll system integrations
-- ERP and inventory system integrations
-- Market data API integrations
-- Other accounting system integrations (Xero, Sage, NetSuite, etc.)
-
-All extensions conform to the core platform's standardized interface and ontology, ensuring consistent data classification and model construction regardless of the source.
-
-## Design Principles
-
-1. **Simplicity and Focus**: The core platform maintains a simple, focused design with only essential data source integrations (QBO and EDGAR). All other functionality is provided through modular, extensible packages that plug into the core.
-
-2. **Standardized Ontology First**: All financial data is mapped to a standardized WACCY chart of accounts, regardless of source system classifications. Input classifications are treated skeptically and normalized to ensure consistency, comparability, and quantifiable quality across all analyses.
-
-3. **Modular Extensibility**: The platform architecture is designed for extensibility, not comprehensiveness. New data sources, model types, and analysis frameworks are added as separate packages that conform to core interfaces, not as monolithic additions to the core platform.
-
-4. **Accuracy First**: Deterministic functions preferred over probabilistic models where possible. LLMs used for parsing and classification, not for financial calculations.
-
-5. **Transparency and Auditability**: Every data point traceable to source, every calculation explainable, every assumption documented, and every classification mapping reviewable.
-
-6. **Professional Standards**: Models adhere to institutional-quality standards for architecture, formatting, and presentation.
-
-7. **Quality Quantification**: The standardized ontology enables measurement and reporting of data quality, classification accuracy, and model output reliability—without standardization, quality cannot be meaningfully assessed.
-
-8. **Scalability**: Platform designed primarily for small businesses—from sole proprietorships to growing companies—with the capability to handle larger enterprises. The focus is on making sophisticated financial modeling accessible to businesses that lack dedicated finance teams and rigorous accounting infrastructure.
-
-9. **User Empowerment**: Users maintain control over assumptions, can override automated extractions and classifications, and can customize model outputs while benefiting from automation. Users install only the data source packages they need.
+LLMs and foundation models can help when ambiguity is real: messy account names, incomplete context, document interpretation, and classification uncertainty. They should assist classification and interpretation, not become a black box for financial calculations.
 
 ## Long-Term Vision
 
-WACCY aims to become the standard platform for automated financial modeling for small businesses, enabling entrepreneurs, small business owners, investors, and advisors to generate sophisticated financial analyses with minimal manual effort—even when source data is messy, incomplete, or poorly maintained. By intelligently synthesizing data from diverse sources and learning from high-quality examples in EDGAR filings, the platform democratizes access to institutional-quality financial modeling capabilities for businesses that lack dedicated finance teams.
+WACCY should become a standard open platform for automated financial modeling from imperfect business records. Over time, it should support extraction from accounting systems, public filings, documents, banking systems, CRMs, payroll systems, and other operational sources, while maintaining a consistent ontology and auditable modeling layer.
 
-The ultimate goal is to enable small business owners and their advisors to answer complex financial questions quickly and accurately: What is this business worth? How would a transaction structure impact returns? What are the key risks and sensitivities? How does this company compare to its peers? By automating the tedious work of data extraction, normalization of messy records, and model construction—while learning from thousands of high-quality examples of how large companies handle similar financial scenarios—WACCY allows users to focus on strategic analysis and decision-making rather than wrestling with incomplete QuickBooks records and ambiguous account classifications.
+The long-term goal is simple: users should spend less time wrestling with incomplete records and more time making informed decisions.
+
+## Where Details Live
+
+This mission document intentionally stays high-level. The detailed product, modeling, and technical commitments live in:
+
+- [1-EXPERIENCE.md](1-EXPERIENCE.md): user workflows, diagnostics, and release experience
+- [2-REQUIREMENTS.md](2-REQUIREMENTS.md): financial modeling requirements and roadmap
+- [3-ARCHITECTURE.md](3-ARCHITECTURE.md): data-source strategy, ontology, extensions, and implementation design

--- a/docs/1-EXPERIENCE.md
+++ b/docs/1-EXPERIENCE.md
@@ -1,0 +1,78 @@
+# WACCY Experience
+
+This document describes the target user experience for WACCY. The current package is still an early scaffold; the first useful workflow is tracked in the [v0.1.0 milestone](https://github.com/DecisionNerd/waccy/milestone/1).
+
+## Primary Users
+
+WACCY should serve people who need professional financial analysis but start from imperfect records:
+
+- advisors and accountants cleaning up small-business financials
+- investors, lenders, and buyers evaluating small companies
+- operators and founders trying to understand performance and cash flow
+- developers building automated finance workflows
+
+The product should assume the user is capable and busy. It should avoid magic, expose uncertainty, and make review efficient.
+
+## v0.1.0 Target Workflow
+
+The first usable release should make one narrow path feel solid:
+
+1. Install WACCY with the QBO and EDGAR extensions.
+2. Load QBO/QuickBooks or EDGAR fixture data.
+3. Normalize source accounts into the WACCY chart of accounts.
+4. Build a three-statement model.
+5. Export an `.xlsx` workbook with:
+   - Income Statement
+   - Balance Sheet
+   - Cash Flow Statement
+6. Review validation and reconciliation checks.
+
+## Target End-To-End Experience
+
+In the long run, WACCY should guide users through a repeatable workflow:
+
+1. **Connect or load sources**: accounting data, public filings, documents, or other business systems.
+2. **Inspect extracted data**: source accounts, periods, amounts, and provenance.
+3. **Review mappings**: see how source accounts map to WACCY standard accounts.
+4. **Resolve ambiguity**: accept, override, or flag uncertain classifications.
+5. **Build models**: generate financial statements and model outputs from normalized data.
+6. **Validate outputs**: review balance checks, cash-flow tie-outs, missing data, and confidence scores.
+7. **Export and iterate**: produce workbook outputs that remain auditable and editable.
+
+The experience should make the quality of the data visible before the user relies on the model.
+
+## User Expectations
+
+The v0.1.0 experience should be explicit about data quality. If source accounts cannot be mapped, periods are missing, or the balance sheet does not balance, WACCY should return actionable diagnostics rather than quietly producing a bad model.
+
+Users should be able to answer:
+
+- Which source records produced this line item?
+- Which accounts were mapped automatically?
+- Which accounts were ambiguous or unmapped?
+- Which periods are incomplete?
+- Does the balance sheet balance?
+- Does cash flow tie to the change in cash?
+- What assumptions or defaults did WACCY use?
+
+## Data Quality Experience
+
+WACCY should treat messy records as normal, not exceptional. When input data is incomplete or ambiguous, the user experience should:
+
+- identify the issue clearly
+- show the source data involved
+- explain the likely impact on the model
+- provide an override or review path where appropriate
+- preserve the audit trail after correction
+
+Confidence scoring should help prioritize review. It should not imply false precision.
+
+## Non-Goals For v0.1.0
+
+The following are important to the broader mission but should not block the first vertical slice:
+
+- Full live QuickBooks OAuth flow beyond a documented integration path
+- Full EDGAR pattern-learning system
+- DCF, LBO, M&A, SaaS cohort, or other advanced model types
+- Google Sheets API export
+- LLM-dependent classification as a required path

--- a/docs/2-EXPERIENCE.md
+++ b/docs/2-EXPERIENCE.md
@@ -1,1 +1,0 @@
-# User Experience

--- a/docs/2-REQUIREMENTS.md
+++ b/docs/2-REQUIREMENTS.md
@@ -1,8 +1,68 @@
-## Financial modeling skills, methods, and model types
+# WACCY Requirements
+
+This document captures the financial modeling requirements, methods, and deliverables that shape WACCY's roadmap. The v0.1.0 release is intentionally narrower than this full list: it targets QBO/QuickBooks and EDGAR inputs, normalized accounts, a three-statement model, validation checks, and XLSX export.
+
+## v0.1.0 Release Requirements
+
+The first useful release should prove the core modeling loop with a narrow, testable vertical slice:
+
+- load QBO/QuickBooks fixture data
+- load EDGAR fixture data
+- produce a normalized financial dataset from both sources
+- normalize source accounts and concepts into WACCY standard accounts
+- validate the mapped financial dataset before model construction
+- build a three-statement model object
+- export an `.xlsx` workbook with Income Statement, Balance Sheet, and Cash Flow Statement sheets
+- report unmapped accounts, missing periods, balance-sheet imbalance, and cash-flow tie-out failures
+- include fixture-driven tests for the full path from source data to workbook
+
+Live integrations can be documented behind clear configuration paths, but fixtures are enough to prove the v0.1.0 modeling loop.
+
+## Data Quality Requirements
+
+WACCY must make data quality measurable and reviewable:
+
+- normalized records should preserve source provenance before mapping
+- every model line item should trace back to source data
+- every source account or concept should map to a canonical WACCY account or appear in diagnostics
+- mappings should carry confidence or review status
+- validation should catch structurally invalid data before model construction
+- reconciliation should catch broken statements after model construction
+- users should be able to inspect and override ambiguous classifications
+
+Quality reporting should prioritize actionability over ornamental scores.
+
+## Layer Requirements
+
+The v0.1.0 implementation should establish the reusable layers that future financial models and metrics will depend on:
+
+- **Raw extracted data**: source-shaped records with provenance.
+- **Normalized financial dataset**: source-agnostic records with periods, accounts or concepts, amounts, units, source system, and provenance.
+- **Mapped financial dataset**: normalized records connected to WACCY standard accounts with confidence and review status.
+- **Validated financial dataset**: mapped records plus diagnostics and reconciliation results.
+- **Model and metric outputs**: source-agnostic builders that consume validated data.
+- **Exports**: rendered workbook or other output formats.
+
+Extractors should not build financial models. Model and metric builders should not depend on source-specific QBO or EDGAR structures.
+
+## Standardization Requirements
+
+All financial data must pass through a standard ontology before it becomes model output. The ontology should support:
+
+- account type and hierarchy
+- statement placement
+- normal balance/sign convention
+- cash-flow classification
+- source aliases for QBO account names and EDGAR/XBRL concepts
+- industry-specific extension without fragmenting the standard
+
+The ontology is a product requirement, not only an implementation detail: without standardization, WACCY cannot compare companies, quantify mapping quality, or generate reliable downstream models.
+
+## Financial Modeling Skills, Methods, And Model Types
 
 ### Model engineering and spreadsheet craft
 
-*Note: Models output to multiple formats, with Google Sheets as the primary spreadsheet platform.*
+*Note: v0.1.0 targets XLSX export. Google Sheets support is a longer-term output option.*
 
 * **Model architecture**: modular tabs, inputs/assumptions separation, consistent time axis, sign conventions, hardcode isolation
 * **Formatting standards**: color conventions, units (000s/MM), date handling, print-ready layouts
@@ -103,4 +163,66 @@
 * **SaaS cohort + unit economics model**
 * **Carve-out / spin / restructuring model (when relevant)**
 
-If you tell me the kinds of companies you’re modeling most (SaaS, services, manufacturing, roll-ups, etc.), I can reorganize this into a tighter “core set + industry add-ons” checklist you can standardize across templates.
+## Phased Roadmap Requirements
+
+### Phase One: Core Foundation And Three-Statement Models
+
+Objective: establish the foundational platform with QBO/QuickBooks and EDGAR fixture-supported extraction, standardized ontology, basic account mapping, model generation, validation, and XLSX export.
+
+Required capabilities:
+
+- core platform architecture with a modular data-source interface
+- minimum WACCY chart of accounts for three-statement modeling
+- deterministic mapping from QBO accounts and EDGAR/XBRL concepts
+- three-statement model generation
+- reconciliation checks and quality diagnostics
+- fixture-driven tests for both QBO and EDGAR paths
+
+### Phase Two: Public Market Data And Pattern Learning
+
+Objective: use SEC EDGAR as both public-company source data and a corpus of professional classification examples.
+
+Required capabilities:
+
+- richer EDGAR extraction from 10-K, 10-Q, and 8-K filings
+- normalization and calendarization of public company periods
+- pattern extraction for classification and causal-chain learning
+- comparison workflows that help interpret small-business data through better-documented examples
+
+### Phase Three: Advanced Valuation Models
+
+Objective: build valuation and transaction analysis on top of standardized three-statement outputs.
+
+Required capabilities:
+
+- DCF valuation
+- trading comparables
+- transaction comparables
+- M&A and pro forma analysis
+- LBO model generation
+- sensitivity and scenario tooling
+
+### Phase Four: Specialized Model Types
+
+Objective: extend WACCY into industry and use-case-specific models.
+
+Required capabilities:
+
+- SaaS cohort and unit economics models
+- real estate and REIT models
+- project finance and infrastructure models
+- cap table and dilution analysis
+- credit and covenant compliance models
+- industry-specific template libraries
+
+### Phase Five: Advanced Analysis And Decision Support
+
+Objective: help users reason across scenarios, risks, and fragmented sources.
+
+Required capabilities:
+
+- multi-scenario model generation
+- automated sensitivity analysis
+- strategic planning models
+- source synthesis from documents and operational systems
+- confidence-aware decision-support outputs

--- a/docs/3-ARCHITECTURE.md
+++ b/docs/3-ARCHITECTURE.md
@@ -9,6 +9,134 @@ WACCY is designed as a core platform with a modular extension architecture. The 
 - **Clean Separation**: Core platform logic independent of data source implementations
 - **Easy Distribution**: Both core and extensions publishable to PyPI independently
 
+## Current Implementation Status
+
+This document describes both the intended architecture and the current scaffold. As of the published package set:
+
+- `waccy` is `0.0.2`
+- `waccy-quickbooks` is `0.1.0`
+- `waccy-edgar` is `0.0.2`
+
+The repository currently contains the core interfaces, public package exports, extension discovery, placeholder extractors, and build/publish tooling. The end-to-end workflow is tracked for [v0.1.0](https://github.com/DecisionNerd/waccy/milestone/1): QBO/QuickBooks and EDGAR inputs, canonical mapping, a three-statement model object, and XLSX export.
+
+## Layered Data Contract
+
+WACCY should keep extraction, normalization, modeling, metrics, and export as separate layers. The v0.1.0 implementation should make these contracts explicit so future model types can reuse the same normalized financial data.
+
+```text
+source extractor
+  -> raw extracted data
+  -> normalized financial dataset
+  -> mapped financial dataset
+  -> validated financial dataset
+  -> model and metric builders
+  -> exporters
+```
+
+### Source Extractor
+
+An extractor is source-specific. It knows how to read QBO, EDGAR, or another system and return source records with provenance. It should not know how to build a three-statement model.
+
+### Raw Extracted Data
+
+Raw extracted data preserves source-native concepts: account names, account IDs, statement labels, transaction IDs, dates, periods, units, and source metadata. This layer is useful for auditability and debugging.
+
+### Normalized Financial Dataset
+
+The normalized financial dataset is the reusable contract between extraction and downstream analysis. It should represent source records in a consistent shape: periods, entities, accounts or concepts, amounts, units, source system, and provenance. It is still allowed to contain source-native account IDs and concepts.
+
+This layer is what lets WACCY support future metric extraction and model types without rewriting extractors.
+
+### Mapped Financial Dataset
+
+The mapped dataset connects normalized records to the WACCY ontology. It adds canonical account IDs, confidence, review status, ambiguity diagnostics, and optional user overrides.
+
+### Validated Financial Dataset
+
+The validated dataset adds quality and reconciliation results: missing periods, unmapped accounts, balance checks, cash-flow tie-outs, and other diagnostics. Model and metric builders should consume this layer rather than raw source data.
+
+### Model And Metric Builders
+
+Builders should be source-agnostic. A three-statement model builder, DCF builder, SaaS metric extractor, covenant calculator, or comparables spreader should consume the validated dataset and ontology metadata rather than source-specific QBO or EDGAR structures.
+
+### Exporters
+
+Exporters render model or metric outputs into files or external systems. v0.1.0 targets XLSX workbook export; other output targets can be added later without changing extractor contracts.
+
+## Data Source Strategy
+
+WACCY keeps the core platform focused while allowing data sources to be added through extension packages. The first-party source strategy centers on QBO/QuickBooks and SEC EDGAR because they solve different parts of the small-business modeling problem.
+
+### QBO / QuickBooks
+
+QBO is the primary small-business accounting source. The integration should extract chart of accounts, financial statements, general ledger or transaction-level detail, and metadata needed to preserve source provenance.
+
+Architecturally, QBO data should not be trusted blindly. Source account names and account types are useful signals, but WACCY should still map them through the standard ontology and report confidence or ambiguity.
+
+### SEC EDGAR
+
+EDGAR serves two architectural roles:
+
+- a structured public-company source for comparable financial statement data
+- a reference corpus for professional classification, terminology, and financial-statement patterns
+
+For v0.1.0, deterministic EDGAR/XBRL concept mapping is enough to support the vertical slice. Pattern learning can be added later without blocking the first model-generation path.
+
+### Modular Extensions
+
+All other source systems should be added as modular packages that implement the same extractor contract. Examples include:
+
+- Google Drive, Gmail, PDFs, and spreadsheets
+- banking and payment systems
+- CRM and sales systems
+- HR and payroll systems
+- ERP and inventory systems
+- market data APIs
+- other accounting systems such as Xero, Sage, and NetSuite
+
+The core platform should remain source-agnostic after extraction. All sources must normalize into the shared financial dataset contract and then map into the WACCY ontology before model construction or metric extraction.
+
+## Parsing And Classification Philosophy
+
+WACCY should use deterministic logic wherever source structures are known:
+
+- structured APIs for QBO and other accounting systems
+- XBRL/company-facts structures for EDGAR
+- explicit mappings for known account names, account types, and concepts
+- formulaic financial statement construction and reconciliation
+
+LLMs can assist where ambiguity is unavoidable:
+
+- ambiguous account names
+- incomplete context
+- document interpretation
+- classification suggestions
+- relationship inference between source records
+
+LLMs should not be the authority for financial calculations. They may propose classifications or explanations, but deterministic validation and reconciliation must remain the guardrails.
+
+## Standard Ontology Architecture
+
+The standard chart of accounts is the canonical layer between source data and model output. It should include:
+
+- canonical account IDs and names
+- account type and hierarchy
+- statement placement
+- normal balance and sign convention
+- cash-flow section and treatment
+- source aliases for QBO accounts and EDGAR/XBRL concepts
+- metadata for confidence, review status, and auditability
+
+The ontology enables:
+
+- consistent model construction across sources
+- cross-company comparison
+- mapping quality measurement
+- downstream model extensibility
+- user review of ambiguous or unmapped accounts
+
+Industry-specific templates can extend the ontology, but they should map back to standard parent accounts so customization does not destroy comparability.
+
 ## Project Structure
 
 ### Core Package (`waccy`)
@@ -24,9 +152,12 @@ waccy/
 ├── CODE_OF_CONDUCT.md
 ├── docs/
 │   ├── 0-MISSION.md
-│   ├── 1-ARCHITECTURE.md
-│   ├── 2-EXPERIENCE.md
-│   └── skills_models.md
+│   ├── 1-EXPERIENCE.md
+│   ├── 2-REQUIREMENTS.md
+│   ├── 3-ARCHITECTURE.md
+│   ├── assets/
+│   ├── examples/
+│   └── references/
 ├── src/
 │   └── waccy/
 │       ├── __init__.py
@@ -44,7 +175,7 @@ waccy/
 │       │   ├── __init__.py
 │       │   ├── builder.py            # Model construction logic
 │       │   ├── templates.py          # Model templates
-│       │   └── exporters.py          # Google Sheets export
+│       │   └── exporters.py          # Spreadsheet export
 │       ├── classification/
 │       │   ├── __init__.py
 │       │   ├── engine.py             # LLM-enhanced classification
@@ -71,41 +202,26 @@ Extension packages follow a consistent naming convention and structure:
 ```
 waccy-quickbooks/
 ├── pyproject.toml
-├── uv.lock
 ├── README.md
 ├── src/
 │   └── waccy_quickbooks/
 │       ├── __init__.py
-│       ├── client.py                # QuickBooks API client
 │       ├── extractor.py             # Implements waccy.extraction.base.Extractor
-│       └── mapper.py                # QBO-specific mappings
-└── tests/
+│       └── ...
+└── dist/
 
 waccy-edgar/
 ├── pyproject.toml
-├── uv.lock
 ├── README.md
 ├── src/
 │   └── waccy_edgar/
 │       ├── __init__.py
-│       ├── client.py                # SEC EDGAR API client
-│       ├── extractor.py             # Filing parser and extractor
-│       ├── parser.py                # 10-K, 10-Q parsing
-│       └── patterns.py              # Pattern extraction for learning
-└── tests/
-
-waccy-google/
-├── pyproject.toml
-├── uv.lock
-├── README.md
-├── src/
-│   └── waccy_google/
-│       ├── __init__.py
-│       ├── drive.py                 # Google Drive integration
-│       ├── gmail.py                 # Gmail integration
-│       └── extractor.py             # Document/email extractor
-└── tests/
+│       ├── extractor.py             # Implements waccy.extraction.base.Extractor
+│       └── ...
+└── dist/
 ```
+
+Future extension packages may add clients, parsers, mappers, and tests as implementation grows. Those files should be added when the corresponding integration work lands.
 
 ## Package Configuration
 
@@ -114,7 +230,7 @@ waccy-google/
 ```toml
 [project]
 name = "waccy"
-version = "0.1.0"
+version = "0.0.2"
 description = "Intelligent financial modeling platform for small businesses"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -143,8 +259,8 @@ dependencies = [
 
 [project.optional-dependencies]
 # Core extensions (maintained by WACCY team)
-quickbooks = ["waccy-quickbooks>=0.1.0"]
-edgar = ["waccy-edgar>=0.1.0"]
+quickbooks = ["waccy-quickbooks>=0.0.1"]
+edgar = ["waccy-edgar>=0.0.1"]
 # Community extensions listed in docs but not as dependencies
 
 [project.scripts]
@@ -221,13 +337,13 @@ disallow_untyped_defs = false
 ```toml
 [project]
 name = "waccy-{name}"
-version = "0.1.0"
+version = "0.0.1"
 description = "WACCY extension for {description}"
 readme = "README.md"
 requires-python = ">=3.13"
 license = { text = "MIT" }
 dependencies = [
-    "waccy>=0.1.0",  # Core platform dependency
+    "waccy>=0.0.2",  # Core platform dependency
     # Extension-specific dependencies
 ]
 
@@ -281,7 +397,10 @@ class ExtractorRegistry:
         """Discover extensions via entry points"""
         discovered = entry_points(group="waccy.extractors")
         for ep in discovered:
-            extractor_class = ep.load()
+            try:
+                extractor_class = ep.load()
+            except (ImportError, ModuleNotFoundError):
+                continue
             instance = extractor_class()
             self._extractors[instance.data_source] = extractor_class
     
@@ -467,14 +586,14 @@ class ModelBuilder:
         # 2. Build historical statements
         # 3. Apply forecasting logic
         # 4. Ensure balance checks
-        ...
+        raise NotImplementedError("3-statement model not yet implemented")
     
     def export_to_sheets(
         self, 
         model: "ThreeStatementModel",
         output_path: str
     ):
-        """Export model to Google Sheets"""
+        """Export model to spreadsheet output."""
         ...
 ```
 
@@ -491,7 +610,7 @@ uv init --name waccy_{name} --package
 
 2. **Add core dependency**:
 ```toml
-dependencies = ["waccy>=0.1.0"]
+dependencies = ["waccy>=0.0.2"]
 ```
 
 3. **Implement Extractor**:

--- a/docs/4-TESTING.md
+++ b/docs/4-TESTING.md
@@ -1,0 +1,155 @@
+# WACCY Testing And Quality
+
+WACCY's testing strategy should protect the financial correctness of the platform, not only the mechanics of individual functions. The quality loop is designed around issue-sized changes, local pre-push checks, GitHub CI, Codecov coverage gates, CodeRabbit review, and outcome-oriented BDD specs.
+
+## Quality Standard
+
+Every meaningful change should answer three questions before it merges:
+
+- Does the code satisfy the user-visible outcome described by the issue?
+- Do the financial calculations, mappings, validations, and exports remain correct?
+- Can a reviewer trust the checks without manually reconstructing the whole model path?
+
+For WACCY, "correct" means more than green unit tests. A change should preserve source provenance, mapping status, validation diagnostics, reconciliation checks, and workbook outputs.
+
+## Local Pre-Push Workflow
+
+The default development loop is:
+
+1. Work one GitHub issue at a time.
+2. Add or update outcome expectations when product behavior changes.
+3. Run local checks before pushing.
+4. Push the branch.
+5. Open a ready-for-review PR, not a draft PR.
+6. Let GitHub CI, Codecov, and CodeRabbit verify the same branch.
+
+Run:
+
+```bash
+make pre-push
+```
+
+`make pre-push` is intentionally aligned with CI. It runs:
+
+```bash
+uv run ruff check
+uv run mypy src/waccy
+uv run pytest tests/bdd -q -m "bdd or outcome"
+uv run pytest --cov=src/waccy --cov-report=term-missing --cov-report=xml --cov-fail-under=90
+```
+
+The Makefile also exposes smaller targets for faster iteration:
+
+```bash
+make lint
+make typecheck
+make bdd
+make test
+make test-cov
+```
+
+## Coverage Target
+
+The project coverage target is 90%.
+
+This target is enforced in two places:
+
+- local and CI pytest coverage with `--cov-fail-under=90`
+- Codecov project and patch gates set to `90%`
+
+Coverage should be meaningful. Tests should exercise behavior, edge cases, validation branches, source-specific mapping, and exported artifacts. Avoid adding superficial tests that only execute lines without protecting a user or financial outcome.
+
+Low-coverage scaffolding should either gain useful tests or remain clearly marked as placeholder behavior. As the codebase matures, placeholder modules should be replaced by real behavior and real tests rather than excluded from coverage by default.
+
+## Test Layers
+
+WACCY uses layered tests that mirror the architecture:
+
+- **Unit tests** cover deterministic behavior in models, ontology, mapping, validation, utilities, and exporters.
+- **Fixture-driven tests** cover QBO and EDGAR source-shaped inputs without live API dependencies.
+- **Integration-style pipeline tests** cover the path from extracted records to normalized datasets, mapped records, validated datasets, three-statement models, and XLSX workbooks.
+- **BDD outcome specs** cover user-visible expectations in business language.
+- **CI checks** verify the complete branch before merge.
+
+The core v0.1.0 outcome path is:
+
+```text
+source extractor
+  -> raw extracted data
+  -> normalized financial dataset
+  -> mapped financial dataset
+  -> validated financial dataset
+  -> model builders
+  -> XLSX exporter
+```
+
+Tests should preserve that contract.
+
+## BDD Outcome Specs
+
+BDD specs live under:
+
+```text
+tests/bdd/features/
+tests/bdd/test_*_outcomes.py
+```
+
+Feature files should describe outcomes in user-facing terms. They should focus on what must be true, not how the code happens to implement it.
+
+Good BDD scenarios answer questions like:
+
+- Can a balanced QBO fixture produce exactly the expected three statements?
+- Can EDGAR/XBRL concepts map into the same canonical model as QBO?
+- Does the model surface unmapped accounts, ambiguous mappings, balance-sheet failures, or cash-flow tie-out failures?
+- Does a workbook export contain the expected sheets, periods, line items, and check rows?
+
+BDD specs should not replace unit tests. They define the acceptance contract. Unit and integration tests then protect the implementation details behind that contract.
+
+## GitHub CI
+
+GitHub Actions runs two jobs:
+
+- **Quality Gates**: ruff, mypy, full pytest coverage, Codecov upload.
+- **BDD Outcome Specs**: focused behavior checks so outcome regressions are visible in the PR.
+
+CI should remain fast enough to support issue-by-issue work. If a future test category becomes slow, split it into an explicit job rather than hiding it inside a broad command.
+
+## Codecov
+
+Codecov checks both project coverage and patch coverage. The target is 90%, with small thresholds to avoid noise from harmless rounding or incidental line shifts.
+
+Codecov is a guardrail, not the sole quality signal. A PR can have high coverage and still be wrong if it lacks outcome coverage, bad financial assumptions, or weak validation checks.
+
+## CodeRabbit
+
+CodeRabbit is configured through `.coderabbit.yaml` and should review ready PRs. It is expected to provide an additional code-review pass, especially on:
+
+- financial calculation mistakes
+- unclear abstractions
+- missing tests
+- API contract breaks
+- documentation drift
+- CI or workflow mistakes
+
+CodeRabbit comments should be triaged like normal review feedback. Fix actionable issues, explain intentional tradeoffs, and keep the PR moving through the same checks.
+
+## Issue-To-PR Discipline
+
+The preferred workflow is one issue, one focused branch, one ready PR.
+
+Each issue should include:
+
+- the intended user-visible outcome
+- feature expectations that can become BDD scenarios when behavior changes
+- implementation notes for likely modules or APIs
+- done criteria for BDD coverage, unit/integration coverage, and passing CI
+
+Each PR should include:
+
+- the linked issue
+- the outcome delivered
+- tests added or updated
+- local `make pre-push` result
+- any known gaps or follow-up issues
+
+Draft PRs are not the default workflow because they interrupt the expected review and CI process. If a branch needs exploratory feedback, say so explicitly; otherwise PRs should be opened ready for review after `make pre-push` passes.

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -69,7 +69,7 @@ python scripts/publish-extension.py waccy-quickbooks --token pypi-<your-token>
    ```
 5. Add dependency on `waccy` in `pyproject.toml`:
    ```toml
-   dependencies = ["waccy>=0.0.2a"]
+   dependencies = ["waccy>=0.0.2"]
    ```
 
 ## Extension Package Requirements
@@ -90,4 +90,3 @@ Each extension package must:
 - **Unified versioning**: Coordinate releases across packages
 - **Simplified CI/CD**: Test all packages together
 - **Independent publishing**: Each package can be published separately to PyPI
-

--- a/extensions/waccy-edgar/README.md
+++ b/extensions/waccy-edgar/README.md
@@ -2,6 +2,14 @@
 
 WACCY extension for SEC EDGAR filing parsing and pattern learning.
 
+## Status
+
+This package currently provides the extension package shell and entry point for `ExtractorRegistry` discovery. EDGAR fetching, parsing, and extraction are not implemented yet. The v0.1.0 work is tracked in:
+
+- [#6 Implement EDGAR extraction for comparable three-statement source data](https://github.com/DecisionNerd/waccy/issues/6)
+- [#14 Decide and implement EDGAR pattern-learning scope for v0.1.0](https://github.com/DecisionNerd/waccy/issues/14)
+- [v0.1.0 milestone](https://github.com/DecisionNerd/waccy/milestone/1)
+
 ## Installation
 
 ```bash
@@ -14,7 +22,17 @@ Or install with the core platform:
 uv pip install "waccy[edgar]"
 ```
 
-## Usage
+## Current Usage
+
+```python
+from waccy.extraction import ExtractorRegistry
+
+registry = ExtractorRegistry()
+extractor = registry.get_extractor("edgar")()
+print(extractor.name)
+```
+
+The following target API is planned but not runnable yet:
 
 ```python
 from waccy.extraction import ExtractorRegistry
@@ -33,4 +51,3 @@ data = extractor.extract({
 ## Development
 
 This package is part of the WACCY monorepo. See the main [README](../README.md) for development setup.
-

--- a/extensions/waccy-edgar/README.md
+++ b/extensions/waccy-edgar/README.md
@@ -4,7 +4,7 @@ WACCY extension for SEC EDGAR filing parsing and pattern learning.
 
 ## Status
 
-This package currently provides the extension package shell and entry point for `ExtractorRegistry` discovery. EDGAR fetching, parsing, and extraction are not implemented yet. The v0.1.0 work is tracked in:
+This package currently provides fixture-first EDGAR/XBRL-shaped extraction and the entry point for `ExtractorRegistry` discovery. Live EDGAR fetching and richer filing parsing are not implemented yet. The v0.1.0 work is tracked in:
 
 - [#6 Implement EDGAR extraction for comparable three-statement source data](https://github.com/DecisionNerd/waccy/issues/6)
 - [#14 Decide and implement EDGAR pattern-learning scope for v0.1.0](https://github.com/DecisionNerd/waccy/issues/14)
@@ -32,7 +32,7 @@ extractor = registry.get_extractor("edgar")()
 print(extractor.name)
 ```
 
-The following target API is planned but not runnable yet:
+The following live API path is planned but not runnable yet:
 
 ```python
 from waccy.extraction import ExtractorRegistry

--- a/extensions/waccy-edgar/pyproject.toml
+++ b/extensions/waccy-edgar/pyproject.toml
@@ -48,6 +48,8 @@ packages = ["src/waccy_edgar"]
 [tool.ruff]
 line-length = 100
 target-version = "py313"
+
+[tool.ruff.lint]
 select = ["E", "W", "F", "I", "B", "C4", "UP", "ARG", "SIM", "TCH", "PTH", "ERA", "PL", "PERF", "RET", "RUF"]
 ignore = ["E501", "PLR0913", "PLR2004"]
 
@@ -74,4 +76,3 @@ strict_equality = true
 [[tool.mypy.overrides]]
 module = "tests.*"
 disallow_untyped_defs = false
-

--- a/extensions/waccy-edgar/src/waccy_edgar/__init__.py
+++ b/extensions/waccy-edgar/src/waccy_edgar/__init__.py
@@ -1,4 +1,3 @@
 """WACCY extension for SEC EDGAR filing parsing."""
 
-__version__ = "0.1.0"
-
+__version__ = "0.0.2"

--- a/extensions/waccy-edgar/src/waccy_edgar/extractor.py
+++ b/extensions/waccy-edgar/src/waccy_edgar/extractor.py
@@ -43,6 +43,8 @@ class EdgarExtractor(Extractor):
         raw_periods = fixture.get("periods", [])
         if not isinstance(raw_periods, list):
             raise ValueError("EDGAR fixture periods must be a list.")
+        if not all(isinstance(period, dict) for period in raw_periods):
+            raise ValueError("EDGAR fixture periods must be dictionaries.")
 
         periods = [_period_from_dict(period) for period in raw_periods]
         records = [source_record_from_dict(record, self.data_source) for record in raw_records]

--- a/extensions/waccy-edgar/src/waccy_edgar/extractor.py
+++ b/extensions/waccy-edgar/src/waccy_edgar/extractor.py
@@ -68,6 +68,11 @@ class EdgarExtractor(Extractor):
 
 
 def _period_from_dict(data: dict[str, Any]) -> ReportingPeriod:
+    missing_keys = {"label", "start_date", "end_date"} - data.keys()
+    if missing_keys:
+        missing = ", ".join(sorted(missing_keys))
+        raise ValueError(f"EDGAR fixture period is missing required keys: {missing}. Period: {data!r}")
+
     return ReportingPeriod(
         label=str(data["label"]),
         start_date=date.fromisoformat(str(data["start_date"])),

--- a/extensions/waccy-edgar/src/waccy_edgar/extractor.py
+++ b/extensions/waccy-edgar/src/waccy_edgar/extractor.py
@@ -31,14 +31,21 @@ class EdgarExtractor(Extractor):
     def extract(self, config: dict[str, Any]) -> ExtractedData:
         """Extract data from an EDGAR-shaped fixture or dictionary."""
         fixture = config.get("fixture") or config.get("data") or config
-        if "records" not in fixture:
-            raise ValueError("EDGAR fixture extraction requires a 'records' list.")
+        if not isinstance(fixture, dict):
+            raise ValueError("EDGAR fixture extraction requires a dictionary payload.")
 
-        periods = [_period_from_dict(period) for period in fixture.get("periods", [])]
-        records = [
-            source_record_from_dict(record, self.data_source)
-            for record in fixture["records"]
-        ]
+        raw_records = fixture.get("records")
+        if not isinstance(raw_records, list):
+            raise ValueError("EDGAR fixture extraction requires a 'records' list.")
+        if not all(isinstance(record, dict) for record in raw_records):
+            raise ValueError("EDGAR fixture records must be dictionaries.")
+
+        raw_periods = fixture.get("periods", [])
+        if not isinstance(raw_periods, list):
+            raise ValueError("EDGAR fixture periods must be a list.")
+
+        periods = [_period_from_dict(period) for period in raw_periods]
+        records = [source_record_from_dict(record, self.data_source) for record in raw_records]
         return ExtractedData(
             entity_name=str(fixture.get("entity_name", config.get("ticker", "EDGAR Entity"))),
             periods=periods,

--- a/extensions/waccy-edgar/src/waccy_edgar/extractor.py
+++ b/extensions/waccy-edgar/src/waccy_edgar/extractor.py
@@ -30,7 +30,12 @@ class EdgarExtractor(Extractor):
 
     def extract(self, config: dict[str, Any]) -> ExtractedData:
         """Extract data from an EDGAR-shaped fixture or dictionary."""
-        fixture = config.get("fixture") or config.get("data") or config
+        if "fixture" in config:
+            fixture = config["fixture"]
+        elif "data" in config:
+            fixture = config["data"]
+        else:
+            fixture = config
         if not isinstance(fixture, dict):
             raise ValueError("EDGAR fixture extraction requires a dictionary payload.")
 

--- a/extensions/waccy-edgar/src/waccy_edgar/extractor.py
+++ b/extensions/waccy-edgar/src/waccy_edgar/extractor.py
@@ -1,12 +1,17 @@
-"""SEC EDGAR extractor implementation."""
+"""SEC EDGAR fixture-first extractor implementation."""
 
+from __future__ import annotations
+
+from datetime import date
 from typing import Any
 
-from waccy.extraction.base import ExtractedData, Extractor
+from waccy.core.models import ExtractedData, PeriodType, ReportingPeriod
+from waccy.extraction.base import Extractor
+from waccy.extraction.mapper import source_record_from_dict
 
 
 class EdgarExtractor(Extractor):
-    """Extractor for SEC EDGAR filings."""
+    """Extractor for SEC EDGAR-shaped fixture data."""
 
     @property
     def name(self) -> str:
@@ -19,19 +24,39 @@ class EdgarExtractor(Extractor):
         return "edgar"
 
     def authenticate(self, credentials: dict[str, str]) -> bool:
-        """Authenticate with SEC EDGAR (no authentication required)."""
-        # EDGAR is publicly accessible, no authentication needed
+        """Authenticate with SEC EDGAR fixture mode."""
+        del credentials
         return True
 
     def extract(self, config: dict[str, Any]) -> ExtractedData:
-        """Extract data from SEC EDGAR filings."""
-        # TODO: Implement EDGAR extraction
-        # This will:
-        # 1. Fetch filings from SEC EDGAR API
-        # 2. Parse 10-K, 10-Q, 8-K filings
-        # 3. Extract financial statements
-        # 4. Extract pattern data for learning
-        # 5. Map to WACCY standard accounts
-        # 6. Return ExtractedData
-        raise NotImplementedError("EDGAR extraction not yet implemented")
+        """Extract data from an EDGAR-shaped fixture or dictionary."""
+        fixture = config.get("fixture") or config.get("data") or config
+        if "records" not in fixture:
+            raise ValueError("EDGAR fixture extraction requires a 'records' list.")
 
+        periods = [_period_from_dict(period) for period in fixture.get("periods", [])]
+        records = [
+            source_record_from_dict(record, self.data_source)
+            for record in fixture["records"]
+        ]
+        return ExtractedData(
+            entity_name=str(fixture.get("entity_name", config.get("ticker", "EDGAR Entity"))),
+            periods=periods,
+            source_records=records,
+            metadata={
+                "source": self.data_source,
+                "mode": "fixture",
+                "ticker": config.get("ticker"),
+                **dict(fixture.get("metadata", {})),
+            },
+            quality_score=1.0,
+        )
+
+
+def _period_from_dict(data: dict[str, Any]) -> ReportingPeriod:
+    return ReportingPeriod(
+        label=str(data["label"]),
+        start_date=date.fromisoformat(str(data["start_date"])),
+        end_date=date.fromisoformat(str(data["end_date"])),
+        period_type=PeriodType(str(data.get("period_type", "year"))),
+    )

--- a/extensions/waccy-quickbooks/README.md
+++ b/extensions/waccy-quickbooks/README.md
@@ -4,7 +4,7 @@ WACCY extension for QuickBooks Online integration.
 
 ## Status
 
-This package currently provides the extension package shell and entry point for `ExtractorRegistry` discovery. QuickBooks authentication and data extraction are not implemented yet. The v0.1.0 work is tracked in:
+This package currently provides fixture-first QuickBooks/QBO-shaped extraction and the entry point for `ExtractorRegistry` discovery. Live QuickBooks OAuth and API extraction are not implemented yet. The v0.1.0 work is tracked in:
 
 - [#5 Implement QuickBooks/QBO extraction for three-statement source data](https://github.com/DecisionNerd/waccy/issues/5)
 - [v0.1.0 milestone](https://github.com/DecisionNerd/waccy/milestone/1)
@@ -27,17 +27,17 @@ uv pip install "waccy[quickbooks]"
 from waccy.extraction import ExtractorRegistry
 
 registry = ExtractorRegistry()
-extractor = registry.get_extractor("quickbooks")()
+extractor = registry.get_extractor("qbo")()
 print(extractor.name)
 ```
 
-The following target API is planned but not runnable yet:
+The following live API path is planned but not runnable yet:
 
 ```python
 from waccy.extraction import ExtractorRegistry
 
 registry = ExtractorRegistry()
-extractor = registry.get_extractor("quickbooks")()
+extractor = registry.get_extractor("qbo")()
 
 # Authenticate
 extractor.authenticate({

--- a/extensions/waccy-quickbooks/README.md
+++ b/extensions/waccy-quickbooks/README.md
@@ -2,6 +2,13 @@
 
 WACCY extension for QuickBooks Online integration.
 
+## Status
+
+This package currently provides the extension package shell and entry point for `ExtractorRegistry` discovery. QuickBooks authentication and data extraction are not implemented yet. The v0.1.0 work is tracked in:
+
+- [#5 Implement QuickBooks/QBO extraction for three-statement source data](https://github.com/DecisionNerd/waccy/issues/5)
+- [v0.1.0 milestone](https://github.com/DecisionNerd/waccy/milestone/1)
+
 ## Installation
 
 ```bash
@@ -14,7 +21,17 @@ Or install with the core platform:
 uv pip install "waccy[quickbooks]"
 ```
 
-## Usage
+## Current Usage
+
+```python
+from waccy.extraction import ExtractorRegistry
+
+registry = ExtractorRegistry()
+extractor = registry.get_extractor("quickbooks")()
+print(extractor.name)
+```
+
+The following target API is planned but not runnable yet:
 
 ```python
 from waccy.extraction import ExtractorRegistry
@@ -39,4 +56,3 @@ data = extractor.extract({
 ## Development
 
 This package is part of the WACCY monorepo. See the main [README](../README.md) for development setup.
-

--- a/extensions/waccy-quickbooks/pyproject.toml
+++ b/extensions/waccy-quickbooks/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "waccy-quickbooks"
-version = "0.0.2"
+version = "0.1.0"
 description = "WACCY extension for QuickBooks Online integration"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -10,7 +10,7 @@ authors = [
 ]
 keywords = ["finance", "financial-modeling", "accounting", "quickbooks", "waccy"]
 classifiers = [
-    "Development Status :: 2 - Pre-Alpha",
+    "Development Status :: 3 - Alpha",
     "Intended Audience :: Financial and Insurance Industry",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3.13",
@@ -48,6 +48,8 @@ packages = ["src/waccy_quickbooks"]
 [tool.ruff]
 line-length = 100
 target-version = "py313"
+
+[tool.ruff.lint]
 select = ["E", "W", "F", "I", "B", "C4", "UP", "ARG", "SIM", "TCH", "PTH", "ERA", "PL", "PERF", "RET", "RUF"]
 ignore = ["E501", "PLR0913", "PLR2004"]
 
@@ -74,4 +76,3 @@ strict_equality = true
 [[tool.mypy.overrides]]
 module = "tests.*"
 disallow_untyped_defs = false
-

--- a/extensions/waccy-quickbooks/src/waccy_quickbooks/extractor.py
+++ b/extensions/waccy-quickbooks/src/waccy_quickbooks/extractor.py
@@ -76,6 +76,11 @@ class QuickBooksExtractor(Extractor):
 
 
 def _period_from_dict(data: dict[str, Any]) -> ReportingPeriod:
+    missing_keys = {"label", "start_date", "end_date"} - data.keys()
+    if missing_keys:
+        missing = ", ".join(sorted(missing_keys))
+        raise ValueError(f"QuickBooks fixture period is missing required keys: {missing}. Period: {data!r}")
+
     return ReportingPeriod(
         label=str(data["label"]),
         start_date=date.fromisoformat(str(data["start_date"])),

--- a/extensions/waccy-quickbooks/src/waccy_quickbooks/extractor.py
+++ b/extensions/waccy-quickbooks/src/waccy_quickbooks/extractor.py
@@ -34,14 +34,21 @@ class QuickBooksExtractor(Extractor):
     def extract(self, config: dict[str, Any]) -> ExtractedData:
         """Extract data from a QuickBooks-shaped fixture or dictionary."""
         fixture = config.get("fixture") or config.get("data") or config
-        if "records" not in fixture:
-            raise ValueError("QuickBooks fixture extraction requires a 'records' list.")
+        if not isinstance(fixture, dict):
+            raise ValueError("QuickBooks fixture extraction requires a dictionary payload.")
 
-        periods = [_period_from_dict(period) for period in fixture.get("periods", [])]
-        records = [
-            source_record_from_dict(record, self.data_source)
-            for record in fixture["records"]
-        ]
+        raw_records = fixture.get("records")
+        if not isinstance(raw_records, list):
+            raise ValueError("QuickBooks fixture extraction requires a 'records' list.")
+        if not all(isinstance(record, dict) for record in raw_records):
+            raise ValueError("QuickBooks fixture records must be dictionaries.")
+
+        raw_periods = fixture.get("periods", [])
+        if not isinstance(raw_periods, list):
+            raise ValueError("QuickBooks fixture periods must be a list.")
+
+        periods = [_period_from_dict(period) for period in raw_periods]
+        records = [source_record_from_dict(record, self.data_source) for record in raw_records]
         return ExtractedData(
             entity_name=str(fixture.get("entity_name", config.get("company_id", "QuickBooks Entity"))),
             periods=periods,

--- a/extensions/waccy-quickbooks/src/waccy_quickbooks/extractor.py
+++ b/extensions/waccy-quickbooks/src/waccy_quickbooks/extractor.py
@@ -1,12 +1,17 @@
-"""QuickBooks Online extractor implementation."""
+"""QuickBooks Online fixture-first extractor implementation."""
 
+from __future__ import annotations
+
+from datetime import date
 from typing import Any
 
-from waccy.extraction.base import ExtractedData, Extractor
+from waccy.core.models import ExtractedData, PeriodType, ReportingPeriod
+from waccy.extraction.base import Extractor
+from waccy.extraction.mapper import source_record_from_dict
 
 
 class QuickBooksExtractor(Extractor):
-    """Extractor for QuickBooks Online data."""
+    """Extractor for QuickBooks Online-shaped fixture data."""
 
     @property
     def name(self) -> str:
@@ -16,22 +21,45 @@ class QuickBooksExtractor(Extractor):
     @property
     def data_source(self) -> str:
         """Data source identifier."""
-        return "quickbooks"
+        return "qbo"
 
     def authenticate(self, credentials: dict[str, str]) -> bool:
-        """Authenticate with QuickBooks Online."""
-        # TODO: Implement QuickBooks OAuth authentication
-        # This will use the QuickBooks API to get access tokens
+        """Accept fixture-mode authentication.
+
+        Live QuickBooks OAuth is intentionally out of scope for v0.1.0.
+        """
+        del credentials
         return True
 
     def extract(self, config: dict[str, Any]) -> ExtractedData:
-        """Extract data from QuickBooks Online."""
-        # TODO: Implement data extraction
-        # This will:
-        # 1. Connect to QuickBooks API
-        # 2. Extract chart of accounts
-        # 3. Extract transactions
-        # 4. Map to WACCY standard accounts
-        # 5. Return ExtractedData
-        raise NotImplementedError("QuickBooks extraction not yet implemented")
+        """Extract data from a QuickBooks-shaped fixture or dictionary."""
+        fixture = config.get("fixture") or config.get("data") or config
+        if "records" not in fixture:
+            raise ValueError("QuickBooks fixture extraction requires a 'records' list.")
 
+        periods = [_period_from_dict(period) for period in fixture.get("periods", [])]
+        records = [
+            source_record_from_dict(record, self.data_source)
+            for record in fixture["records"]
+        ]
+        return ExtractedData(
+            entity_name=str(fixture.get("entity_name", config.get("company_id", "QuickBooks Entity"))),
+            periods=periods,
+            source_records=records,
+            accounts=list(fixture.get("accounts", [])),
+            metadata={
+                "source": self.data_source,
+                "mode": "fixture",
+                **dict(fixture.get("metadata", {})),
+            },
+            quality_score=1.0,
+        )
+
+
+def _period_from_dict(data: dict[str, Any]) -> ReportingPeriod:
+    return ReportingPeriod(
+        label=str(data["label"]),
+        start_date=date.fromisoformat(str(data["start_date"])),
+        end_date=date.fromisoformat(str(data["end_date"])),
+        period_type=PeriodType(str(data.get("period_type", "year"))),
+    )

--- a/extensions/waccy-quickbooks/src/waccy_quickbooks/extractor.py
+++ b/extensions/waccy-quickbooks/src/waccy_quickbooks/extractor.py
@@ -33,7 +33,12 @@ class QuickBooksExtractor(Extractor):
 
     def extract(self, config: dict[str, Any]) -> ExtractedData:
         """Extract data from a QuickBooks-shaped fixture or dictionary."""
-        fixture = config.get("fixture") or config.get("data") or config
+        if "fixture" in config:
+            fixture = config["fixture"]
+        elif "data" in config:
+            fixture = config["data"]
+        else:
+            fixture = config
         if not isinstance(fixture, dict):
             raise ValueError("QuickBooks fixture extraction requires a dictionary payload.")
 
@@ -46,6 +51,8 @@ class QuickBooksExtractor(Extractor):
         raw_periods = fixture.get("periods", [])
         if not isinstance(raw_periods, list):
             raise ValueError("QuickBooks fixture periods must be a list.")
+        if not all(isinstance(period, dict) for period in raw_periods):
+            raise ValueError("QuickBooks fixture periods must be dictionaries.")
 
         periods = [_period_from_dict(period) for period in raw_periods]
         records = [source_record_from_dict(record, self.data_source) for record in raw_records]

--- a/extensions/waccy-quickbooks/src/waccy_quickbooks/extractor.py
+++ b/extensions/waccy-quickbooks/src/waccy_quickbooks/extractor.py
@@ -49,11 +49,16 @@ class QuickBooksExtractor(Extractor):
 
         periods = [_period_from_dict(period) for period in raw_periods]
         records = [source_record_from_dict(record, self.data_source) for record in raw_records]
+        raw_accounts = fixture.get("accounts", [])
+        if not isinstance(raw_accounts, list):
+            raise ValueError("QuickBooks fixture accounts must be a list.")
+        if not all(isinstance(account, dict) for account in raw_accounts):
+            raise ValueError("QuickBooks fixture accounts must be dictionaries.")
         return ExtractedData(
             entity_name=str(fixture.get("entity_name", config.get("company_id", "QuickBooks Entity"))),
             periods=periods,
             source_records=records,
-            accounts=list(fixture.get("accounts", [])),
+            accounts=raw_accounts,
             metadata={
                 "source": self.data_source,
                 "mode": "fixture",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,6 @@ dev = [
     "pytest-cov>=6.0.0",
     "ruff>=0.8.0",
     "mypy>=1.13.0",
-    "pytest-bdd>=8.1.0",
 ]
 docs = [
     "mkdocs>=1.6.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
 ]
 dependencies = [
     "numpy>=2.3.5",
+    "openpyxl>=3.1.5",
     "pandera>=0.27.0",
     "polars>=1.36.1",
     "pydantic>=2.12.5",
@@ -48,10 +49,12 @@ packages = ["src/waccy"]
 
 [dependency-groups]
 dev = [
+    "pytest-bdd>=8.1.0",
     "pytest>=9.0.2",
     "pytest-cov>=6.0.0",
     "ruff>=0.8.0",
     "mypy>=1.13.0",
+    "pytest-bdd>=8.1.0",
 ]
 docs = [
     "mkdocs>=1.6.1",
@@ -60,6 +63,8 @@ docs = [
 [tool.ruff]
 line-length = 100
 target-version = "py313"
+
+[tool.ruff.lint]
 select = [
     "E",   # pycodestyle errors
     "W",   # pycodestyle warnings
@@ -109,3 +114,17 @@ strict_equality = true
 [[tool.mypy.overrides]]
 module = "tests.*"
 disallow_untyped_defs = false
+
+[[tool.mypy.overrides]]
+module = ["openpyxl", "openpyxl.*"]
+ignore_missing_imports = true
+disable_error_code = ["import-untyped"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = [".", "src"]
+bdd_features_base_dir = "tests/bdd/features"
+markers = [
+    "bdd: outcome-oriented behavior specifications",
+    "outcome: product expectation tests written from user-visible outcomes",
+]

--- a/scripts/build-extension.py
+++ b/scripts/build-extension.py
@@ -1,6 +1,7 @@
 """Build a specific extension package."""
 
 import argparse
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -22,8 +23,6 @@ def build_extension(extension_name: str, clean: bool = False) -> int:
         dist_dir = extension_dir / "dist"
         if dist_dir.exists():
             print(f"Cleaning {dist_dir}...")
-            import shutil
-
             shutil.rmtree(dist_dir)
 
     print(f"Building {extension_name}...")
@@ -85,4 +84,3 @@ Examples:
 
 if __name__ == "__main__":
     sys.exit(main())
-

--- a/scripts/publish-extension.py
+++ b/scripts/publish-extension.py
@@ -20,7 +20,7 @@ def publish_extension(
 
     dist_dir = extension_dir / "dist"
     if not dist_dir.exists() or not list(dist_dir.glob("*")):
-        print(f"❌ No distribution files found. Build first with:")
+        print("❌ No distribution files found. Build first with:")
         print(f"   python scripts/build-extension.py {extension_name}")
         return 1
 

--- a/scripts/publish.py
+++ b/scripts/publish.py
@@ -1,6 +1,7 @@
 """Helper script for publishing to PyPI."""
 
 import argparse
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -31,8 +32,6 @@ def build_package(clean: bool = False) -> int:
         dist_dir = Path("dist")
         if dist_dir.exists():
             print("Cleaning dist/ directory...")
-            import shutil
-
             shutil.rmtree(dist_dir)
 
     print("Building package...")
@@ -174,14 +173,12 @@ Examples:
             return 0
 
     # Publish
-    publish_result = publish_package(
+    return publish_package(
         testpypi=args.testpypi,
         dry_run=args.dry_run,
         token=args.token,
     )
-    return publish_result
 
 
 if __name__ == "__main__":
     sys.exit(main())
-

--- a/src/waccy/__init__.py
+++ b/src/waccy/__init__.py
@@ -1,21 +1,21 @@
 """WACCY - Intelligent Financial Modeling Platform for Small Businesses."""
 
-__version__ = "0.1.0"
+__version__ = "0.0.2"
 
 # Core exports
+# Classification exports
+from waccy.classification import ClassificationEngine
 from waccy.core import (
     AccountCategory,
     AccountType,
     ExtractedData,
     ExtractedTransaction,
     StandardChartOfAccounts,
+    ThreeStatementModel,
 )
 
 # Extraction exports
 from waccy.extraction import Extractor, ExtractorRegistry
-
-# Classification exports
-from waccy.classification import ClassificationEngine
 
 # Modeling exports
 from waccy.modeling import ModelBuilder
@@ -30,5 +30,5 @@ __all__ = [
     "ExtractorRegistry",
     "ModelBuilder",
     "StandardChartOfAccounts",
+    "ThreeStatementModel",
 ]
-

--- a/src/waccy/classification/confidence.py
+++ b/src/waccy/classification/confidence.py
@@ -14,6 +14,7 @@ class ConfidenceScorer:
         validation_results: dict[str, Any],
     ) -> float:
         """Calculate confidence score for an account mapping."""
+        del source_account, mapped_account, transaction_patterns, validation_results
         # TODO: Implement confidence scoring logic
         # Factors to consider:
         # - Name similarity
@@ -21,4 +22,3 @@ class ConfidenceScorer:
         # - Validation results
         # - Historical accuracy
         return 0.0
-

--- a/src/waccy/classification/engine.py
+++ b/src/waccy/classification/engine.py
@@ -1,6 +1,5 @@
 """LLM-powered classification for ambiguous accounts."""
 
-from typing import Optional
 
 from waccy.core.ontology import AccountCategory, StandardChartOfAccounts
 
@@ -8,7 +7,7 @@ from waccy.core.ontology import AccountCategory, StandardChartOfAccounts
 class ClassificationEngine:
     """LLM-powered classification for ambiguous accounts."""
 
-    def __init__(self, llm_provider: Optional[str] = None) -> None:
+    def __init__(self, llm_provider: str | None = None) -> None:
         """Initialize the classification engine."""
         self.ontology = StandardChartOfAccounts()
         self.llm_provider = llm_provider

--- a/src/waccy/classification/patterns.py
+++ b/src/waccy/classification/patterns.py
@@ -1,6 +1,6 @@
 """Pattern matching from EDGAR filings."""
 
-from typing import Any, Optional
+from typing import Any
 
 
 class PatternMatcher:
@@ -12,11 +12,12 @@ class PatternMatcher:
 
     def extract_patterns(self, filing_data: dict) -> dict[str, Any]:
         """Extract classification patterns from filing data."""
+        del filing_data
         # TODO: Implement pattern extraction
         return {}
 
-    def match_pattern(self, account_name: str, transaction_data: list[dict]) -> Optional[dict]:
+    def match_pattern(self, account_name: str, transaction_data: list[dict]) -> dict | None:
         """Match account against learned patterns."""
+        del account_name, transaction_data
         # TODO: Implement pattern matching
         return None
-

--- a/src/waccy/cli.py
+++ b/src/waccy/cli.py
@@ -1,10 +1,9 @@
 """Command-line interface for WACCY."""
 
 import sys
-from typing import Optional
 
 
-def main(args: Optional[list[str]] = None) -> int:
+def main(args: list[str] | None = None) -> int:
     """Main CLI entry point."""
     if args is None:
         args = sys.argv[1:]

--- a/src/waccy/core/__init__.py
+++ b/src/waccy/core/__init__.py
@@ -1,15 +1,50 @@
 """Core platform components: ontology, models, and validation."""
 
-from waccy.core.models import ExtractedData, ExtractedTransaction
+from waccy.core.models import (
+    ExtractedData,
+    ExtractedTransaction,
+    FinancialStatement,
+    IssueSeverity,
+    MappedFinancialDataset,
+    MappedFinancialRecord,
+    MappingDiagnostic,
+    MappingOverride,
+    MappingStatus,
+    NormalizedFinancialDataset,
+    PeriodType,
+    ReportingPeriod,
+    SourceRecord,
+    SourceReference,
+    StatementLine,
+    ThreeStatementModel,
+    ValidatedFinancialDataset,
+    ValidationIssue,
+)
 from waccy.core.ontology import AccountCategory, AccountType, StandardChartOfAccounts
-from waccy.core.validation import validate_extracted_data
+from waccy.core.validation import validate_extracted_data, validate_mapped_dataset
 
 __all__ = [
     "AccountCategory",
     "AccountType",
     "ExtractedData",
     "ExtractedTransaction",
+    "FinancialStatement",
+    "IssueSeverity",
+    "MappedFinancialDataset",
+    "MappedFinancialRecord",
+    "MappingDiagnostic",
+    "MappingOverride",
+    "MappingStatus",
+    "NormalizedFinancialDataset",
+    "PeriodType",
+    "ReportingPeriod",
+    "SourceRecord",
+    "SourceReference",
     "StandardChartOfAccounts",
+    "StatementLine",
+    "ThreeStatementModel",
+    "ValidatedFinancialDataset",
+    "ValidationIssue",
     "validate_extracted_data",
+    "validate_mapped_dataset",
 ]
-

--- a/src/waccy/core/models.py
+++ b/src/waccy/core/models.py
@@ -1,37 +1,209 @@
-"""Core data models for extracted financial data."""
+"""Core data models for WACCY's layered financial data contract."""
 
-from datetime import date
-from decimal import Decimal
-from typing import Any
+from __future__ import annotations
+
+from datetime import date  # noqa: TC003
+from decimal import Decimal  # noqa: TC003
+from enum import Enum
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
 
+class PeriodType(str, Enum):
+    """Supported reporting period granularities."""
+
+    MONTH = "month"
+    QUARTER = "quarter"
+    YEAR = "year"
+
+
+class MappingStatus(str, Enum):
+    """Review state for a source-to-standard account mapping."""
+
+    MAPPED = "mapped"
+    AMBIGUOUS = "ambiguous"
+    OVERRIDDEN = "overridden"
+    UNMAPPED = "unmapped"
+
+
+class IssueSeverity(str, Enum):
+    """Validation issue severity."""
+
+    INFO = "info"
+    WARNING = "warning"
+    ERROR = "error"
+
+
+class SourceReference(BaseModel):
+    """Pointer back to a source system record."""
+
+    source_system: str
+    source_id: str
+    source_label: str = ""
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class ReportingPeriod(BaseModel):
+    """A reporting period used as a model column."""
+
+    label: str
+    start_date: date
+    end_date: date
+    period_type: PeriodType = PeriodType.YEAR
+
+
+class SourceRecord(BaseModel):
+    """A source-shaped financial record before WACCY account mapping."""
+
+    source_account_id: str
+    source_account_name: str
+    amount: Decimal
+    period_label: str
+    source: SourceReference
+    unit: str = "USD"
+    statement: str | None = None
+    source_account_type: str | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class NormalizedFinancialDataset(BaseModel):
+    """Source-agnostic records with source-native account/concept identity preserved."""
+
+    entity_name: str
+    periods: list[ReportingPeriod]
+    records: list[SourceRecord]
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class MappingDiagnostic(BaseModel):
+    """Explanation for a mapping decision or issue."""
+
+    code: str
+    message: str
+
+
+class MappingOverride(BaseModel):
+    """Caller-provided account mapping override."""
+
+    account_id: str
+    note: str = ""
+
+
+class MappedFinancialRecord(BaseModel):
+    """A normalized record mapped to the WACCY ontology."""
+
+    source_record: SourceRecord
+    account_id: str | None = None
+    account_name: str | None = None
+    status: MappingStatus
+    confidence: float = Field(ge=0.0, le=1.0)
+    diagnostics: list[MappingDiagnostic] = Field(default_factory=list)
+    override_note: str | None = None
+
+
+class MappedFinancialDataset(BaseModel):
+    """Normalized financial data after source-to-standard account mapping."""
+
+    entity_name: str
+    periods: list[ReportingPeriod]
+    records: list[MappedFinancialRecord]
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class ValidationIssue(BaseModel):
+    """A validation or reconciliation issue."""
+
+    code: str
+    message: str
+    severity: IssueSeverity = IssueSeverity.ERROR
+    period_label: str | None = None
+    account_id: str | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class ValidatedFinancialDataset(BaseModel):
+    """Mapped financial data plus validation diagnostics."""
+
+    mapped_dataset: MappedFinancialDataset
+    issues: list[ValidationIssue] = Field(default_factory=list)
+
+    @property
+    def is_valid(self) -> bool:
+        """Return whether the dataset has no error-level issues."""
+        return not any(issue.severity == IssueSeverity.ERROR for issue in self.issues)
+
+
 class ExtractedTransaction(BaseModel):
-    """Standard transaction format."""
+    """Legacy transaction format retained for compatibility."""
 
     date: date
-    account_id: str  # Mapped to WACCY standard
+    account_id: str
     amount: Decimal
     description: str
     source_id: str
-    confidence: float = Field(ge=0.0, le=1.0)  # Mapping confidence score
+    confidence: float = Field(default=1.0, ge=0.0, le=1.0)
 
 
 class ExtractedData(BaseModel):
-    """Standard extracted data format."""
+    """Extractor output that can carry source records into the layered contract."""
 
-    transactions: list[ExtractedTransaction]
-    accounts: list[dict[str, Any]]  # Account metadata
-    metadata: dict[str, Any]
-    quality_score: float = Field(ge=0.0, le=1.0)
+    transactions: list[ExtractedTransaction] = Field(default_factory=list)
+    accounts: list[dict[str, Any]] = Field(default_factory=list)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    quality_score: float = Field(default=1.0, ge=0.0, le=1.0)
+    entity_name: str = "Unknown Entity"
+    periods: list[ReportingPeriod] = Field(default_factory=list)
+    source_records: list[SourceRecord] = Field(default_factory=list)
 
     def generate_quality_report(self) -> dict[str, Any]:
-        """Generate a quality report for the extracted data."""
-        # TODO: Implement quality report generation
+        """Generate a basic quality report for extracted data."""
+        record_count = len(self.source_records) + len(self.transactions)
+        mapped_transactions = [txn for txn in self.transactions if txn.account_id]
+        avg_confidence = (
+            sum(txn.confidence for txn in self.transactions) / len(self.transactions)
+            if self.transactions
+            else self.quality_score
+        )
+        issues = []
+        if record_count == 0:
+            issues.append("No source records or transactions were extracted.")
+        if self.transactions and len(mapped_transactions) != len(self.transactions):
+            issues.append("Some transactions are missing account mappings.")
         return {
-            "completeness": 0.0,
-            "avg_confidence": 0.0,
-            "issues": [],
+            "completeness": 1.0 if record_count else 0.0,
+            "avg_confidence": avg_confidence,
+            "issues": issues,
         }
 
+
+class StatementLine(BaseModel):
+    """A line item in a financial statement."""
+
+    label: str
+    account_id: str | None = None
+    values: dict[str, Decimal] = Field(default_factory=dict)
+    is_subtotal: bool = False
+    is_check: bool = False
+    source_account_ids: list[str] = Field(default_factory=list)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class FinancialStatement(BaseModel):
+    """A financial statement composed of ordered line items."""
+
+    name: Literal["Income Statement", "Balance Sheet", "Cash Flow Statement"]
+    periods: list[ReportingPeriod]
+    lines: list[StatementLine]
+
+
+class ThreeStatementModel(BaseModel):
+    """Source-agnostic three-statement model output."""
+
+    entity_name: str
+    periods: list[ReportingPeriod]
+    income_statement: FinancialStatement
+    balance_sheet: FinancialStatement
+    cash_flow_statement: FinancialStatement
+    validation_issues: list[ValidationIssue] = Field(default_factory=list)
+    metadata: dict[str, Any] = Field(default_factory=dict)

--- a/src/waccy/core/ontology.py
+++ b/src/waccy/core/ontology.py
@@ -1,9 +1,10 @@
 """Standardized chart of accounts and financial ontology."""
 
-from enum import Enum
-from typing import Optional
+from __future__ import annotations
 
-from pydantic import BaseModel
+from enum import Enum
+
+from pydantic import BaseModel, Field
 
 
 class AccountType(str, Enum):
@@ -14,6 +15,7 @@ class AccountType(str, Enum):
     EQUITY = "equity"
     REVENUE = "revenue"
     EXPENSE = "expense"
+    CASH_FLOW = "cash_flow"
 
 
 class AccountCategory(BaseModel):
@@ -22,9 +24,18 @@ class AccountCategory(BaseModel):
     id: str
     name: str
     type: AccountType
-    parent_id: Optional[str] = None
+    parent_id: str | None = None
     level: int
     description: str
+    statement: str | None = None
+    normal_balance: str = "debit"
+    cash_flow_section: str | None = None
+    sort_order: int = 0
+    aliases: list[str] = Field(default_factory=list)
+
+
+def _key(value: str) -> str:
+    return "".join(ch for ch in value.lower() if ch.isalnum())
 
 
 class StandardChartOfAccounts:
@@ -33,31 +44,79 @@ class StandardChartOfAccounts:
     def __init__(self) -> None:
         """Initialize the standard chart of accounts."""
         self.accounts: dict[str, AccountCategory] = {}
+        self._aliases: dict[str, list[str]] = {}
         self._initialize_standard_accounts()
 
+    def _add_account(self, account: AccountCategory) -> None:
+        self.accounts[account.id] = account
+        self._aliases.setdefault(_key(account.id), []).append(account.id)
+        self._aliases.setdefault(_key(account.name), []).append(account.id)
+        for alias in account.aliases:
+            self._aliases.setdefault(_key(alias), []).append(account.id)
+
     def _initialize_standard_accounts(self) -> None:
-        """Initialize the standard chart of accounts."""
-        # TODO: Implement comprehensive standard chart of accounts
-        # Income statement accounts
-        # Balance sheet accounts
-        # Cash flow accounts
-        # Supporting schedules
-        pass
+        """Initialize the minimum chart of accounts for v0.1.0."""
+        account_specs = [
+            ("revenue", "Revenue", AccountType.REVENUE, "income_statement", "credit", None, 100, ["sales", "sales revenue", "total revenue", "us-gaap:revenues", "revenues"]),
+            ("cogs", "Cost of Goods Sold", AccountType.EXPENSE, "income_statement", "debit", None, 200, ["cost of goods sold", "cost of revenue", "cost of sales", "us-gaap:costofrevenue"]),
+            ("operating_expenses", "Operating Expenses", AccountType.EXPENSE, "income_statement", "debit", None, 300, ["opex", "operating expense", "operating expenses", "general and administrative", "sg&a", "us-gaap:sellinggeneralandadministrativeexpense"]),
+            ("depreciation_amortization", "Depreciation & Amortization", AccountType.EXPENSE, "income_statement", "debit", None, 350, ["depreciation", "amortization", "d&a", "us-gaap:depreciationdepletionandamortization"]),
+            ("interest_expense", "Interest Expense", AccountType.EXPENSE, "income_statement", "debit", None, 400, ["interest", "interest expense", "us-gaap:interestexpense"]),
+            ("tax_expense", "Tax Expense", AccountType.EXPENSE, "income_statement", "debit", None, 500, ["tax", "income tax", "income tax expense", "us-gaap:incometaxexpensebenefit"]),
+            ("cash", "Cash", AccountType.ASSET, "balance_sheet", "debit", None, 1000, ["bank", "cash and cash equivalents", "checking", "savings", "us-gaap:cashandcashequivalentsatcarryingvalue"]),
+            ("accounts_receivable", "Accounts Receivable", AccountType.ASSET, "balance_sheet", "debit", None, 1100, ["accounts receivable", "ar", "a/r", "us-gaap:accountsreceivablenetcurrent"]),
+            ("inventory", "Inventory", AccountType.ASSET, "balance_sheet", "debit", None, 1200, ["inventory", "stock", "us-gaap:inventorynet"]),
+            ("ppe", "Property, Plant & Equipment", AccountType.ASSET, "balance_sheet", "debit", None, 1300, ["fixed assets", "property plant and equipment", "ppe", "pp&e", "us-gaap:propertyplantandequipmentnet"]),
+            ("accumulated_depreciation", "Accumulated Depreciation", AccountType.ASSET, "balance_sheet", "credit", None, 1350, ["accumulated depreciation", "us-gaap:accumulateddepreciationdepletionandamortizationpropertyplantandequipment"]),
+            ("accounts_payable", "Accounts Payable", AccountType.LIABILITY, "balance_sheet", "credit", None, 2000, ["accounts payable", "ap", "a/p", "us-gaap:accountspayablecurrent"]),
+            ("accrued_expenses", "Accrued Expenses", AccountType.LIABILITY, "balance_sheet", "credit", None, 2100, ["accrued expenses", "accruals", "accrued liabilities", "us-gaap:accruedliabilitiescurrent"]),
+            ("debt", "Debt", AccountType.LIABILITY, "balance_sheet", "credit", None, 2200, ["loan", "loans", "notes payable", "debt", "long-term debt", "us-gaap:longtermdebtcurrent", "us-gaap:longtermdebtnoncurrent"]),
+            ("equity", "Equity", AccountType.EQUITY, "balance_sheet", "credit", None, 3000, ["owners equity", "owner's equity", "members equity", "stockholders equity", "us-gaap:stockholdersequity"]),
+            ("retained_earnings", "Retained Earnings", AccountType.EQUITY, "balance_sheet", "credit", None, 3100, ["retained earnings", "us-gaap:retainedearningsaccumulateddeficit"]),
+            ("net_income", "Net Income", AccountType.CASH_FLOW, "cash_flow_statement", "credit", "operating", 4000, ["net income", "net earnings", "profit", "us-gaap:netincomeloss"]),
+            ("depreciation_addback", "Depreciation Add-back", AccountType.CASH_FLOW, "cash_flow_statement", "credit", "operating", 4100, ["depreciation addback", "depreciation and amortization", "us-gaap:depreciationdepletionandamortization"]),
+            ("working_capital_movement", "Working Capital Movement", AccountType.CASH_FLOW, "cash_flow_statement", "credit", "operating", 4200, ["change in working capital", "changes in operating assets and liabilities"]),
+            ("capex", "Capital Expenditures", AccountType.CASH_FLOW, "cash_flow_statement", "debit", "investing", 5000, ["capex", "capital expenditures", "purchase of property and equipment", "us-gaap:paymentstoacquirepropertyplantandequipment"]),
+            ("financing_movement", "Financing Movement", AccountType.CASH_FLOW, "cash_flow_statement", "credit", "financing", 6000, ["financing activities", "debt proceeds", "debt repayment", "us-gaap:proceedsfromissuanceoflongtermdebt"]),
+        ]
+        for account_id, name, account_type, statement, normal_balance, cf_section, order, aliases in account_specs:
+            self._add_account(
+                AccountCategory(
+                    id=account_id,
+                    name=name,
+                    type=account_type,
+                    level=1,
+                    description=name,
+                    statement=statement,
+                    normal_balance=normal_balance,
+                    cash_flow_section=cf_section,
+                    sort_order=order,
+                    aliases=aliases,
+                )
+            )
+
+    def map_candidates(self, source_account: str, source_system: str | None = None) -> list[AccountCategory]:
+        """Return possible standard accounts for a source account."""
+        del source_system
+        account_ids = self._aliases.get(_key(source_account), [])
+        return [self.accounts[account_id] for account_id in dict.fromkeys(account_ids)]
 
     def map_account(
         self, source_account: str, source_system: str
-    ) -> Optional[AccountCategory]:
-        """Map a source account to standard account."""
-        # TODO: Implement account mapping logic
+    ) -> AccountCategory | None:
+        """Map a source account to one standard account when deterministic."""
+        candidates = self.map_candidates(source_account, source_system)
+        if len(candidates) == 1:
+            return candidates[0]
         return None
 
-    def get_account(self, account_id: str) -> Optional[AccountCategory]:
+    def get_account(self, account_id: str) -> AccountCategory | None:
         """Get account by ID."""
         return self.accounts.get(account_id)
 
-    def list_accounts(self, account_type: Optional[AccountType] = None) -> list[AccountCategory]:
+    def list_accounts(self, account_type: AccountType | None = None) -> list[AccountCategory]:
         """List all accounts, optionally filtered by type."""
+        accounts = sorted(self.accounts.values(), key=lambda account: account.sort_order)
         if account_type is None:
-            return list(self.accounts.values())
-        return [acc for acc in self.accounts.values() if acc.type == account_type]
-
+            return accounts
+        return [acc for acc in accounts if acc.type == account_type]

--- a/src/waccy/core/validation.py
+++ b/src/waccy/core/validation.py
@@ -1,15 +1,94 @@
-"""Data validation using Pandera schemas."""
+"""Data validation for WACCY financial datasets."""
 
-from waccy.core.models import ExtractedData
+from __future__ import annotations
+
+from waccy.core.models import (
+    ExtractedData,
+    IssueSeverity,
+    MappedFinancialDataset,
+    MappingStatus,
+    ValidatedFinancialDataset,
+    ValidationIssue,
+)
 
 
 def validate_extracted_data(data: ExtractedData) -> bool:
-    """Validate extracted data using Pandera schemas."""
-    # TODO: Implement Pandera schema validation
-    # This will include validation for:
-    # - Transaction data structure
-    # - Account mappings
-    # - Data completeness
-    # - Balance checks
-    return True
+    """Validate extracted data has at least one usable source record or transaction."""
+    return bool(data.source_records or data.transactions)
 
+
+def validate_mapped_dataset(mapped_dataset: MappedFinancialDataset) -> ValidatedFinancialDataset:
+    """Validate a mapped financial dataset and return diagnostics."""
+    issues: list[ValidationIssue] = []
+    seen_periods: set[str] = set()
+    for period in mapped_dataset.periods:
+        if period.label in seen_periods:
+            issues.append(
+                ValidationIssue(
+                    code="duplicate_period",
+                    message=f"Duplicate reporting period {period.label!r}.",
+                    period_label=period.label,
+                )
+            )
+        seen_periods.add(period.label)
+        if period.start_date > period.end_date:
+            issues.append(
+                ValidationIssue(
+                    code="invalid_period_range",
+                    message=f"Period {period.label!r} starts after it ends.",
+                    period_label=period.label,
+                )
+            )
+
+    period_labels = {period.label for period in mapped_dataset.periods}
+    for record in mapped_dataset.records:
+        if record.source_record.period_label not in period_labels:
+            issues.append(
+                ValidationIssue(
+                    code="missing_period",
+                    message=(
+                        f"Record {record.source_record.source.source_id!r} references missing "
+                        f"period {record.source_record.period_label!r}."
+                    ),
+                    period_label=record.source_record.period_label,
+                    account_id=record.account_id,
+                )
+            )
+        if record.status == MappingStatus.UNMAPPED:
+            issues.append(
+                ValidationIssue(
+                    code="unmapped_account",
+                    message=f"Unmapped account {record.source_record.source_account_name!r}.",
+                    severity=IssueSeverity.ERROR,
+                    period_label=record.source_record.period_label,
+                )
+            )
+        elif record.status == MappingStatus.AMBIGUOUS:
+            issues.append(
+                ValidationIssue(
+                    code="ambiguous_mapping",
+                    message=f"Ambiguous account {record.source_record.source_account_name!r}.",
+                    severity=IssueSeverity.WARNING,
+                    period_label=record.source_record.period_label,
+                )
+            )
+        elif record.status == MappingStatus.OVERRIDDEN:
+            issues.append(
+                ValidationIssue(
+                    code="mapping_overridden",
+                    message=f"Mapping overridden for {record.source_record.source_account_name!r}.",
+                    severity=IssueSeverity.INFO,
+                    period_label=record.source_record.period_label,
+                    account_id=record.account_id,
+                )
+            )
+
+    if not mapped_dataset.records:
+        issues.append(
+            ValidationIssue(
+                code="empty_dataset",
+                message="No financial records are available for validation.",
+            )
+        )
+
+    return ValidatedFinancialDataset(mapped_dataset=mapped_dataset, issues=issues)

--- a/src/waccy/core/validation.py
+++ b/src/waccy/core/validation.py
@@ -54,6 +54,18 @@ def validate_mapped_dataset(mapped_dataset: MappedFinancialDataset) -> Validated
                     account_id=record.account_id,
                 )
             )
+        if record.status in {MappingStatus.MAPPED, MappingStatus.OVERRIDDEN} and not record.account_id:
+            issues.append(
+                ValidationIssue(
+                    code="missing_mapped_account_id",
+                    message=(
+                        f"Record {record.source_record.source.source_id!r} is {record.status.value!r} "
+                        "but has no canonical account_id."
+                    ),
+                    severity=IssueSeverity.ERROR,
+                    period_label=record.source_record.period_label,
+                )
+            )
         if record.status == MappingStatus.UNMAPPED:
             issues.append(
                 ValidationIssue(

--- a/src/waccy/core/validation.py
+++ b/src/waccy/core/validation.py
@@ -84,7 +84,7 @@ def validate_mapped_dataset(mapped_dataset: MappedFinancialDataset) -> Validated
                     period_label=record.source_record.period_label,
                 )
             )
-        elif record.status == MappingStatus.OVERRIDDEN:
+        elif record.status == MappingStatus.OVERRIDDEN and record.account_id:
             issues.append(
                 ValidationIssue(
                     code="mapping_overridden",

--- a/src/waccy/extraction/__init__.py
+++ b/src/waccy/extraction/__init__.py
@@ -5,10 +5,9 @@ from waccy.extraction.mapper import DataMapper
 from waccy.extraction.registry import ExtractorRegistry
 
 __all__ = [
+    "DataMapper",
     "ExtractedData",
     "ExtractedTransaction",
     "Extractor",
-    "DataMapper",
     "ExtractorRegistry",
 ]
-

--- a/src/waccy/extraction/base.py
+++ b/src/waccy/extraction/base.py
@@ -3,7 +3,8 @@
 from abc import ABC, abstractmethod
 from typing import Any
 
-from waccy.core.models import ExtractedData
+from waccy.core.models import ExtractedData, ExtractedTransaction
+from waccy.core.validation import validate_extracted_data
 
 
 class Extractor(ABC):
@@ -33,14 +34,6 @@ class Extractor(ABC):
 
     def validate(self, data: ExtractedData) -> bool:
         """Validate extracted data."""
-        # Default implementation using Pandera
-        from waccy.core.validation import validate_extracted_data
-
         return validate_extracted_data(data)
 
-
-# Re-export for convenience
-from waccy.core.models import ExtractedData, ExtractedTransaction  # noqa: E402
-
-__all__ = ["Extractor", "ExtractedData", "ExtractedTransaction"]
-
+__all__ = ["ExtractedData", "ExtractedTransaction", "Extractor"]

--- a/src/waccy/extraction/mapper.py
+++ b/src/waccy/extraction/mapper.py
@@ -1,23 +1,222 @@
-"""Mapping extracted data to standard ontology."""
+"""Mapping extracted data to the WACCY standard ontology."""
 
-from waccy.core.models import ExtractedData
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from typing import Any
+
+from waccy.core.models import (
+    ExtractedData,
+    MappedFinancialDataset,
+    MappedFinancialRecord,
+    MappingDiagnostic,
+    MappingOverride,
+    MappingStatus,
+    NormalizedFinancialDataset,
+    ReportingPeriod,
+    SourceRecord,
+    SourceReference,
+    ValidatedFinancialDataset,
+)
 from waccy.core.ontology import StandardChartOfAccounts
+from waccy.core.validation import validate_mapped_dataset
+
+
+def _period_from_label(label: str) -> ReportingPeriod:
+    year = int(label[:4]) if label[:4].isdigit() else date.today().year
+    return ReportingPeriod(
+        label=label,
+        start_date=date(year, 1, 1),
+        end_date=date(year, 12, 31),
+    )
 
 
 class DataMapper:
-    """Maps extracted data to WACCY standard chart of accounts."""
+    """Maps extracted source data to WACCY standard accounts."""
 
-    def __init__(self) -> None:
+    def __init__(self, ontology: StandardChartOfAccounts | None = None) -> None:
         """Initialize the mapper with standard ontology."""
-        self.ontology = StandardChartOfAccounts()
+        self.ontology = ontology or StandardChartOfAccounts()
 
-    def map_to_standard(self, extracted_data: ExtractedData) -> ExtractedData:
-        """Map extracted data to standard accounts."""
-        # TODO: Implement mapping logic
-        # This will:
-        # 1. Map source accounts to standard accounts
-        # 2. Update transaction account_ids
-        # 3. Calculate confidence scores
-        # 4. Flag unmapped accounts
-        return extracted_data
+    def normalize(self, extracted_data: ExtractedData) -> NormalizedFinancialDataset:
+        """Normalize extractor output into the source-agnostic financial dataset."""
+        records = list(extracted_data.source_records)
+        if not records and extracted_data.transactions:
+            records = [
+                SourceRecord(
+                    source_account_id=txn.account_id,
+                    source_account_name=txn.account_id,
+                    amount=txn.amount,
+                    period_label=str(txn.date.year),
+                    statement=None,
+                    source=SourceReference(
+                        source_system=str(extracted_data.metadata.get("source", "unknown")),
+                        source_id=txn.source_id,
+                        source_label=txn.description,
+                    ),
+                )
+                for txn in extracted_data.transactions
+            ]
 
+        periods_by_label = {period.label: period for period in extracted_data.periods}
+        for record in records:
+            periods_by_label.setdefault(record.period_label, _period_from_label(record.period_label))
+
+        return NormalizedFinancialDataset(
+            entity_name=extracted_data.entity_name,
+            periods=sorted(periods_by_label.values(), key=lambda period: period.start_date),
+            records=records,
+            metadata=extracted_data.metadata,
+        )
+
+    def map_dataset(
+        self,
+        dataset: NormalizedFinancialDataset,
+        overrides: dict[str, str | MappingOverride] | None = None,
+    ) -> MappedFinancialDataset:
+        """Map normalized source records to WACCY standard accounts."""
+        overrides = overrides or {}
+        mapped_records: list[MappedFinancialRecord] = []
+        for record in dataset.records:
+            override = self._find_override(record, overrides)
+            if override is not None:
+                mapped_records.append(self._apply_override(record, override))
+                continue
+
+            candidates = self.ontology.map_candidates(
+                record.source_account_name,
+                record.source.source_system,
+            )
+            if len(candidates) > 1 and record.statement:
+                statement_candidates = [
+                    account for account in candidates if account.statement == record.statement
+                ]
+                if statement_candidates:
+                    candidates = statement_candidates
+            if len(candidates) == 1:
+                account = candidates[0]
+                mapped_records.append(
+                    MappedFinancialRecord(
+                        source_record=record,
+                        account_id=account.id,
+                        account_name=account.name,
+                        status=MappingStatus.MAPPED,
+                        confidence=0.95,
+                    )
+                )
+            elif len(candidates) > 1:
+                mapped_records.append(
+                    MappedFinancialRecord(
+                        source_record=record,
+                        status=MappingStatus.AMBIGUOUS,
+                        confidence=0.4,
+                        diagnostics=[
+                            MappingDiagnostic(
+                                code="ambiguous_mapping",
+                                message=(
+                                    "Source account matched multiple WACCY accounts: "
+                                    + ", ".join(account.id for account in candidates)
+                                ),
+                            )
+                        ],
+                    )
+                )
+            else:
+                mapped_records.append(
+                    MappedFinancialRecord(
+                        source_record=record,
+                        status=MappingStatus.UNMAPPED,
+                        confidence=0.0,
+                        diagnostics=[
+                            MappingDiagnostic(
+                                code="unmapped_account",
+                                message=f"No WACCY account mapping for {record.source_account_name!r}.",
+                            )
+                        ],
+                    )
+                )
+
+        return MappedFinancialDataset(
+            entity_name=dataset.entity_name,
+            periods=dataset.periods,
+            records=mapped_records,
+            metadata=dataset.metadata,
+        )
+
+    def validate(self, mapped_dataset: MappedFinancialDataset) -> ValidatedFinancialDataset:
+        """Validate a mapped dataset."""
+        return validate_mapped_dataset(mapped_dataset)
+
+    def map_to_standard(
+        self,
+        extracted_data: ExtractedData,
+        overrides: dict[str, str | MappingOverride] | None = None,
+    ) -> ValidatedFinancialDataset:
+        """Normalize, map, and validate extracted data."""
+        normalized = self.normalize(extracted_data)
+        mapped = self.map_dataset(normalized, overrides=overrides)
+        return self.validate(mapped)
+
+    def _find_override(
+        self,
+        record: SourceRecord,
+        overrides: dict[str, str | MappingOverride],
+    ) -> str | MappingOverride | None:
+        keys = [
+            record.source_account_id,
+            record.source_account_name,
+            f"{record.source.source_system}:{record.source_account_id}",
+            f"{record.source.source_system}:{record.source_account_name}",
+        ]
+        for key in keys:
+            if key in overrides:
+                return overrides[key]
+        return None
+
+    def _apply_override(
+        self,
+        record: SourceRecord,
+        override: str | MappingOverride,
+    ) -> MappedFinancialRecord:
+        override_model = (
+            override if isinstance(override, MappingOverride) else MappingOverride(account_id=override)
+        )
+        account = self.ontology.get_account(override_model.account_id)
+        diagnostics = []
+        if account is None:
+            diagnostics.append(
+                MappingDiagnostic(
+                    code="invalid_override",
+                    message=f"Override account {override_model.account_id!r} is not in the ontology.",
+                )
+            )
+        return MappedFinancialRecord(
+            source_record=record,
+            account_id=account.id if account else override_model.account_id,
+            account_name=account.name if account else None,
+            status=MappingStatus.OVERRIDDEN,
+            confidence=1.0 if account else 0.0,
+            diagnostics=diagnostics,
+            override_note=override_model.note,
+        )
+
+
+def source_record_from_dict(data: dict[str, Any], source_system: str) -> SourceRecord:
+    """Create a source record from a fixture dictionary."""
+    return SourceRecord(
+        source_account_id=str(data.get("source_account_id") or data.get("account_id") or data["name"]),
+        source_account_name=str(data.get("source_account_name") or data.get("name") or data["account_id"]),
+        amount=Decimal(str(data["amount"])),
+        period_label=str(data["period"]),
+        statement=data.get("statement"),
+        source_account_type=data.get("source_account_type") or data.get("account_type"),
+        unit=str(data.get("unit", "USD")),
+        source=SourceReference(
+            source_system=source_system,
+            source_id=str(data.get("source_id") or data.get("id") or data.get("account_id") or data["name"]),
+            source_label=str(data.get("source_label") or data.get("name") or data.get("account_id")),
+            metadata=dict(data.get("metadata", {})),
+        ),
+        metadata={key: value for key, value in data.items() if key not in {"amount"}},
+    )

--- a/src/waccy/extraction/registry.py
+++ b/src/waccy/extraction/registry.py
@@ -1,11 +1,9 @@
 """Extension registry and discovery for data source extractors."""
 
-from typing import Optional, Protocol, Type
+from importlib.metadata import entry_points
+from typing import Protocol
 
-try:
-    from importlib.metadata import entry_points
-except ImportError:
-    from importlib_metadata import entry_points  # type: ignore
+from waccy.core.models import ExtractedData
 
 
 class ExtractorProtocol(Protocol):
@@ -14,7 +12,7 @@ class ExtractorProtocol(Protocol):
     name: str
     data_source: str
 
-    def extract(self, config: dict) -> "ExtractedData":  # noqa: F821
+    def extract(self, config: dict) -> ExtractedData:
         """Extract data from the source."""
         ...
 
@@ -24,22 +22,21 @@ class ExtractorRegistry:
 
     def __init__(self) -> None:
         """Initialize the registry and load extensions."""
-        self._extractors: dict[str, Type[ExtractorProtocol]] = {}
+        self._extractors: dict[str, type[ExtractorProtocol]] = {}
         self._load_extensions()
 
     def _load_extensions(self) -> None:
         """Discover extensions via entry points."""
-        try:
-            discovered = entry_points(group="waccy.extractors")
-        except TypeError:
-            # Python < 3.10 compatibility
-            discovered = entry_points().get("waccy.extractors", [])
+        discovered = entry_points(group="waccy.extractors")
         for ep in discovered:
-            extractor_class = ep.load()
+            try:
+                extractor_class = ep.load()
+            except (ImportError, ModuleNotFoundError):
+                continue
             instance = extractor_class()
             self._extractors[instance.data_source] = extractor_class
 
-    def get_extractor(self, data_source: str) -> Optional[Type[ExtractorProtocol]]:
+    def get_extractor(self, data_source: str) -> type[ExtractorProtocol] | None:
         """Get extractor class for a data source."""
         return self._extractors.get(data_source)
 
@@ -48,8 +45,7 @@ class ExtractorRegistry:
         return list(self._extractors.keys())
 
     def register_extractor(
-        self, data_source: str, extractor_class: Type[ExtractorProtocol]
+        self, data_source: str, extractor_class: type[ExtractorProtocol]
     ) -> None:
         """Manually register an extractor (useful for testing)."""
         self._extractors[data_source] = extractor_class
-

--- a/src/waccy/modeling/builder.py
+++ b/src/waccy/modeling/builder.py
@@ -1,11 +1,32 @@
-"""Build financial models from extracted data."""
+"""Build financial models from validated WACCY financial datasets."""
 
-from waccy.core.models import ExtractedData
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable  # noqa: TC003
+from decimal import Decimal
+from typing import NoReturn
+
+from waccy.core.models import (
+    ExtractedData,
+    FinancialStatement,
+    IssueSeverity,
+    MappedFinancialDataset,
+    MappedFinancialRecord,
+    StatementLine,
+    ThreeStatementModel,
+    ValidatedFinancialDataset,
+    ValidationIssue,
+)
 from waccy.core.ontology import StandardChartOfAccounts
+from waccy.core.validation import validate_mapped_dataset
+from waccy.extraction.mapper import DataMapper
+from waccy.modeling.exporters import SheetExporter
+
+ZERO = Decimal("0")
 
 
 class ModelBuilder:
-    """Build financial models from extracted data."""
+    """Build financial models from normalized and validated financial data."""
 
     def __init__(self) -> None:
         """Initialize the model builder."""
@@ -13,36 +34,305 @@ class ModelBuilder:
 
     def build_three_statement_model(
         self,
-        extracted_data: ExtractedData,
-        forecast_periods: int = 12,
-    ) -> "ThreeStatementModel":  # noqa: F821
-        """Build integrated 3-statement model."""
-        # TODO: Implement 3-statement model construction
-        # 1. Normalize extracted data to standard accounts
-        # 2. Build historical statements
-        # 3. Apply forecasting logic
-        # 4. Ensure balance checks
-        raise NotImplementedError("3-statement model not yet implemented")
+        extracted_data: ExtractedData | MappedFinancialDataset | ValidatedFinancialDataset,
+        forecast_periods: int = 0,
+    ) -> ThreeStatementModel:
+        """Build an integrated three-statement model."""
+        del forecast_periods
+        validated = self._ensure_validated(extracted_data)
+        dataset = validated.mapped_dataset
+        periods = dataset.periods
+        period_labels = [period.label for period in periods]
+        issues = list(validated.issues)
+
+        income_lines = self._build_income_statement_lines(dataset.records, period_labels)
+        balance_lines = self._build_balance_sheet_lines(dataset.records, period_labels)
+        cash_flow_lines = self._build_cash_flow_lines(dataset.records, income_lines, balance_lines, period_labels)
+        issues.extend(self._statement_issues(balance_lines, cash_flow_lines, period_labels))
+
+        return ThreeStatementModel(
+            entity_name=dataset.entity_name,
+            periods=periods,
+            income_statement=FinancialStatement(
+                name="Income Statement",
+                periods=periods,
+                lines=income_lines,
+            ),
+            balance_sheet=FinancialStatement(
+                name="Balance Sheet",
+                periods=periods,
+                lines=balance_lines,
+            ),
+            cash_flow_statement=FinancialStatement(
+                name="Cash Flow Statement",
+                periods=periods,
+                lines=cash_flow_lines,
+            ),
+            validation_issues=issues,
+            metadata=dataset.metadata,
+        )
 
     def build_dcf_model(
         self,
-        three_statement_model: "ThreeStatementModel",  # noqa: F821
+        three_statement_model: ThreeStatementModel,
         wacc: float,
         terminal_growth_rate: float,
         exit_multiple: float,
-    ) -> "DCFModel":  # noqa: F821
+    ) -> NoReturn:
         """Build DCF valuation model."""
-        # TODO: Implement DCF model construction
+        del three_statement_model, wacc, terminal_growth_rate, exit_multiple
         raise NotImplementedError("DCF model not yet implemented")
 
     def export_to_sheets(
         self,
-        model: "AnyModel",  # noqa: F821
+        model: ThreeStatementModel,
         output_path: str,
     ) -> None:
-        """Export model to Google Sheets/Excel."""
-        from waccy.modeling.exporters import SheetExporter
-
+        """Export model to spreadsheet output."""
         exporter = SheetExporter()
         exporter.export(model, output_path)
 
+    def _ensure_validated(
+        self,
+        data: ExtractedData | MappedFinancialDataset | ValidatedFinancialDataset,
+    ) -> ValidatedFinancialDataset:
+        if isinstance(data, ValidatedFinancialDataset):
+            return data
+        if isinstance(data, MappedFinancialDataset):
+            return validate_mapped_dataset(data)
+        mapper = DataMapper(self.ontology)
+        return mapper.map_to_standard(data)
+
+    def _build_income_statement_lines(
+        self,
+        records: list[MappedFinancialRecord],
+        period_labels: list[str],
+    ) -> list[StatementLine]:
+        revenue = self._line("Revenue", "revenue", records, period_labels)
+        cogs = self._line("Cost of Goods Sold", "cogs", records, period_labels)
+        opex = self._line("Operating Expenses", "operating_expenses", records, period_labels)
+        da = self._line("Depreciation & Amortization", "depreciation_amortization", records, period_labels)
+        interest = self._line("Interest Expense", "interest_expense", records, period_labels)
+        taxes = self._line("Tax Expense", "tax_expense", records, period_labels)
+        gross_profit = self._computed_line(
+            "Gross Profit",
+            period_labels,
+            lambda period: revenue.values[period] - cogs.values[period],
+        )
+        operating_income = self._computed_line(
+            "Operating Income",
+            period_labels,
+            lambda period: gross_profit.values[period] - opex.values[period] - da.values[period],
+        )
+        pretax_income = self._computed_line(
+            "Pre-Tax Income",
+            period_labels,
+            lambda period: operating_income.values[period] - interest.values[period],
+        )
+        net_income = self._computed_line(
+            "Net Income",
+            period_labels,
+            lambda period: pretax_income.values[period] - taxes.values[period],
+        )
+        return [
+            revenue,
+            cogs,
+            gross_profit,
+            opex,
+            da,
+            operating_income,
+            interest,
+            pretax_income,
+            taxes,
+            net_income,
+        ]
+
+    def _build_balance_sheet_lines(
+        self,
+        records: list[MappedFinancialRecord],
+        period_labels: list[str],
+    ) -> list[StatementLine]:
+        cash = self._line("Cash", "cash", records, period_labels)
+        ar = self._line("Accounts Receivable", "accounts_receivable", records, period_labels)
+        inventory = self._line("Inventory", "inventory", records, period_labels)
+        ppe = self._line("Property, Plant & Equipment", "ppe", records, period_labels)
+        accumulated_depreciation = self._line(
+            "Accumulated Depreciation",
+            "accumulated_depreciation",
+            records,
+            period_labels,
+        )
+        ap = self._line("Accounts Payable", "accounts_payable", records, period_labels)
+        accrued = self._line("Accrued Expenses", "accrued_expenses", records, period_labels)
+        debt = self._line("Debt", "debt", records, period_labels)
+        equity = self._line("Equity", "equity", records, period_labels)
+        retained_earnings = self._line("Retained Earnings", "retained_earnings", records, period_labels)
+        total_assets = self._computed_line(
+            "Total Assets",
+            period_labels,
+            lambda period: cash.values[period]
+            + ar.values[period]
+            + inventory.values[period]
+            + ppe.values[period]
+            - accumulated_depreciation.values[period],
+        )
+        total_liabilities = self._computed_line(
+            "Total Liabilities",
+            period_labels,
+            lambda period: ap.values[period] + accrued.values[period] + debt.values[period],
+        )
+        total_equity = self._computed_line(
+            "Total Equity",
+            period_labels,
+            lambda period: equity.values[period] + retained_earnings.values[period],
+        )
+        balance_check = self._computed_line(
+            "Balance Check",
+            period_labels,
+            lambda period: total_assets.values[period]
+            - total_liabilities.values[period]
+            - total_equity.values[period],
+            is_check=True,
+        )
+        return [
+            cash,
+            ar,
+            inventory,
+            ppe,
+            accumulated_depreciation,
+            total_assets,
+            ap,
+            accrued,
+            debt,
+            total_liabilities,
+            equity,
+            retained_earnings,
+            total_equity,
+            balance_check,
+        ]
+
+    def _build_cash_flow_lines(
+        self,
+        records: list[MappedFinancialRecord],
+        income_lines: list[StatementLine],
+        balance_lines: list[StatementLine],
+        period_labels: list[str],
+    ) -> list[StatementLine]:
+        income_net_income = self._find_line(income_lines, "Net Income")
+        bs_cash = self._find_line(balance_lines, "Cash")
+        net_income = self._line("Net Income", "net_income", records, period_labels)
+        if all(value == ZERO for value in net_income.values.values()):
+            net_income = StatementLine(label="Net Income", values=dict(income_net_income.values))
+        da = self._line("Depreciation Add-back", "depreciation_addback", records, period_labels)
+        if all(value == ZERO for value in da.values.values()):
+            da = self._line("Depreciation Add-back", "depreciation_amortization", records, period_labels)
+        wc = self._line("Working Capital Movement", "working_capital_movement", records, period_labels)
+        capex = self._line("Capital Expenditures", "capex", records, period_labels)
+        financing = self._line("Financing Movement", "financing_movement", records, period_labels)
+        net_change_cash = self._computed_line(
+            "Net Change In Cash",
+            period_labels,
+            lambda period: net_income.values[period]
+            + da.values[period]
+            + wc.values[period]
+            + capex.values[period]
+            + financing.values[period],
+            is_subtotal=True,
+        )
+        cash_flow_tie_out = self._computed_line(
+            "Cash Flow Tie-Out",
+            period_labels,
+            lambda period: self._cash_change(period, period_labels, bs_cash)
+            - net_change_cash.values[period],
+            is_check=True,
+        )
+        return [net_income, da, wc, capex, financing, net_change_cash, cash_flow_tie_out]
+
+    def _line(
+        self,
+        label: str,
+        account_id: str,
+        records: Iterable[MappedFinancialRecord],
+        period_labels: list[str],
+    ) -> StatementLine:
+        values = dict.fromkeys(period_labels, ZERO)
+        source_account_ids: set[str] = set()
+        for record in records:
+            if record.account_id != account_id:
+                continue
+            period = record.source_record.period_label
+            if period in values:
+                values[period] += record.source_record.amount
+                source_account_ids.add(record.source_record.source_account_id)
+        return StatementLine(
+            label=label,
+            account_id=account_id,
+            values=values,
+            source_account_ids=sorted(source_account_ids),
+        )
+
+    def _computed_line(
+        self,
+        label: str,
+        period_labels: list[str],
+        calculate: Callable[[str], Decimal],
+        is_check: bool = False,
+        is_subtotal: bool = True,
+    ) -> StatementLine:
+        return StatementLine(
+            label=label,
+            values={period: calculate(period) for period in period_labels},
+            is_subtotal=is_subtotal,
+            is_check=is_check,
+        )
+
+    def _find_line(self, lines: list[StatementLine], label: str) -> StatementLine:
+        for line in lines:
+            if line.label == label:
+                return line
+        raise ValueError(f"Missing statement line {label!r}.")
+
+    def _cash_change(
+        self,
+        period: str,
+        period_labels: list[str],
+        cash_line: StatementLine,
+    ) -> Decimal:
+        index = period_labels.index(period)
+        if index == 0:
+            return ZERO
+        current_period = period_labels[index]
+        previous_period = period_labels[index - 1]
+        return cash_line.values[current_period] - cash_line.values[previous_period]
+
+    def _statement_issues(
+        self,
+        balance_lines: list[StatementLine],
+        cash_flow_lines: list[StatementLine],
+        period_labels: list[str],
+    ) -> list[ValidationIssue]:
+        issues: list[ValidationIssue] = []
+        balance_check = self._find_line(balance_lines, "Balance Check")
+        cash_flow_tie_out = self._find_line(cash_flow_lines, "Cash Flow Tie-Out")
+        for index, period in enumerate(period_labels):
+            if balance_check.values[period] != ZERO:
+                issues.append(
+                    ValidationIssue(
+                        code="balance_sheet_imbalance",
+                        message=f"Balance sheet does not balance for {period}.",
+                        severity=IssueSeverity.ERROR,
+                        period_label=period,
+                        metadata={"difference": str(balance_check.values[period])},
+                    )
+                )
+            if index > 0 and cash_flow_tie_out.values[period] != ZERO:
+                issues.append(
+                    ValidationIssue(
+                        code="cash_flow_tie_out_failure",
+                        message=f"Cash flow does not tie to cash movement for {period}.",
+                        severity=IssueSeverity.WARNING,
+                        period_label=period,
+                        metadata={"difference": str(cash_flow_tie_out.values[period])},
+                    )
+                )
+        return issues

--- a/src/waccy/modeling/exporters.py
+++ b/src/waccy/modeling/exporters.py
@@ -1,22 +1,72 @@
-"""Export models to various formats (Google Sheets, Excel, etc.)."""
+# mypy: disable-error-code=import-untyped
+"""Export source-agnostic financial models to XLSX workbooks."""
 
-from typing import Any
+from __future__ import annotations
+
+from decimal import Decimal
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from openpyxl import Workbook
+from openpyxl.styles import Font, PatternFill
+from openpyxl.utils import get_column_letter
+
+if TYPE_CHECKING:
+    from openpyxl.worksheet.worksheet import Worksheet
+
+    from waccy.core.models import FinancialStatement, ThreeStatementModel
+
+HEADER_FILL = PatternFill("solid", fgColor="D9EAF7")
+CHECK_FILL = PatternFill("solid", fgColor="FCE4D6")
+CURRENCY_FORMAT = '$#,##0;[Red]($#,##0);"-"'
 
 
 class SheetExporter:
-    """Export financial models to spreadsheet formats."""
+    """Export financial models to three-sheet XLSX workbooks."""
 
-    def export(self, model: Any, output_path: str) -> None:
-        """Export model to spreadsheet file."""
-        # TODO: Implement spreadsheet export
-        # Support for:
-        # - Google Sheets (via API)
-        # - Excel (.xlsx)
-        # - CSV
-        # Professional formatting:
-        # - Color conventions (inputs blue, calculations black, outputs green)
-        # - Proper tab structure
-        # - Balance checks
-        # - Scenario tooling
-        raise NotImplementedError("Sheet export not yet implemented")
+    def export(self, model: ThreeStatementModel, output_path: str) -> None:
+        """Export a three-statement model to an XLSX workbook."""
+        workbook = Workbook()
+        workbook.remove(workbook.active)
 
+        for statement in (
+            model.income_statement,
+            model.balance_sheet,
+            model.cash_flow_statement,
+        ):
+            worksheet = workbook.create_sheet(statement.name)
+            self._write_statement(worksheet, statement)
+
+        path = Path(output_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        workbook.save(path)
+
+    def _write_statement(self, worksheet: Worksheet, statement: FinancialStatement) -> None:
+        worksheet.cell(row=1, column=1, value="Line Item")
+        for column, period in enumerate(statement.periods, start=2):
+            worksheet.cell(row=1, column=column, value=period.label)
+
+        for row, line in enumerate(statement.lines, start=2):
+            label_cell = worksheet.cell(row=row, column=1, value=line.label)
+            if line.is_subtotal or line.is_check:
+                label_cell.font = Font(bold=True)
+            if line.is_check:
+                label_cell.fill = CHECK_FILL
+
+            for column, period in enumerate(statement.periods, start=2):
+                value = line.values.get(period.label, Decimal("0"))
+                value_cell = worksheet.cell(row=row, column=column, value=float(value))
+                value_cell.number_format = CURRENCY_FORMAT
+                if line.is_subtotal or line.is_check:
+                    value_cell.font = Font(bold=True)
+                if line.is_check:
+                    value_cell.fill = CHECK_FILL
+
+        for cell in worksheet[1]:
+            cell.font = Font(bold=True)
+            cell.fill = HEADER_FILL
+
+        worksheet.freeze_panes = "B2"
+        worksheet.column_dimensions["A"].width = 32
+        for column in range(2, len(statement.periods) + 2):
+            worksheet.column_dimensions[get_column_letter(column)].width = 14

--- a/src/waccy/modeling/templates.py
+++ b/src/waccy/modeling/templates.py
@@ -23,6 +23,6 @@ class ModelTemplate:
 
     def apply_template(self, data: dict[str, Any]) -> dict[str, Any]:
         """Apply template to data."""
+        del data
         # TODO: Implement template application
         return {}
-

--- a/src/waccy/utils/dates.py
+++ b/src/waccy/utils/dates.py
@@ -1,10 +1,9 @@
 """Date utility functions."""
 
 from datetime import date
-from typing import Optional, Tuple
 
 
-def parse_date_range(date_range: str | Tuple[str, str]) -> Tuple[date, date]:
+def parse_date_range(date_range: str | tuple[str, str]) -> tuple[date, date]:
     """Parse a date range string or tuple into date objects."""
     if isinstance(date_range, tuple):
         start_str, end_str = date_range

--- a/src/waccy/utils/validation.py
+++ b/src/waccy/utils/validation.py
@@ -1,6 +1,7 @@
 """Validation utility functions."""
 
 from datetime import date
+from math import isnan
 
 
 def validate_date_range(start: date, end: date) -> bool:
@@ -10,5 +11,4 @@ def validate_date_range(start: date, end: date) -> bool:
 
 def validate_amount(amount: float | int) -> bool:
     """Validate that amount is a valid number."""
-    return isinstance(amount, (int, float)) and not (isinstance(amount, float) and amount != amount)  # Check for NaN
-
+    return isinstance(amount, (int, float)) and not (isinstance(amount, float) and isnan(amount))

--- a/tests/bdd/features/three_statement_model.feature
+++ b/tests/bdd/features/three_statement_model.feature
@@ -1,0 +1,21 @@
+@bdd @outcome
+Feature: v0.1.0 three-sheet financial model
+  WACCY turns source-specific financial records into a validated workbook-ready model.
+
+  Scenario: QBO fixture produces three validated statements
+    Given a balanced QBO financial fixture
+    When I build the v0.1.0 workbook model
+    Then the workbook has exactly the three expected statements
+    And the 2024 income statement reports net income of 316
+    And the 2024 balance sheet balance check is zero
+    And the 2024 cash flow tie-out is zero
+    And the model has no error-level validation issues
+
+  Scenario: EDGAR fixture maps XBRL concepts into the same canonical model
+    Given a balanced EDGAR financial fixture
+    When I build the v0.1.0 workbook model
+    Then the workbook has exactly the three expected statements
+    And the 2024 income statement reports revenue of 1200
+    And the 2024 balance sheet balance check is zero
+    And the 2024 cash flow tie-out is zero
+    And the model has no error-level validation issues

--- a/tests/bdd/test_three_statement_model_outcomes.py
+++ b/tests/bdd/test_three_statement_model_outcomes.py
@@ -1,0 +1,97 @@
+"""Outcome-oriented BDD specs for the v0.1.0 financial model slice."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any
+
+from pytest_bdd import given, parsers, scenarios, then, when
+
+from tests.fixtures.sample_data import sample_edgar_fixture, sample_periods, sample_qbo_fixture
+from waccy.core.models import ExtractedData, IssueSeverity, StatementLine, ThreeStatementModel
+from waccy.extraction.mapper import source_record_from_dict
+from waccy.modeling.builder import ModelBuilder
+
+scenarios("three_statement_model.feature")
+
+
+@given(parsers.parse("a balanced {source_name} financial fixture"), target_fixture="source_fixture")
+def balanced_financial_fixture(source_name: str) -> dict[str, Any]:
+    """Provide a source-specific fixture by source name."""
+    source_key = source_name.lower()
+    if source_key == "qbo":
+        return {"source": "qbo", "fixture": sample_qbo_fixture()}
+    if source_key == "edgar":
+        return {"source": "edgar", "fixture": sample_edgar_fixture()}
+    raise AssertionError(f"Unsupported source fixture {source_name!r}")
+
+
+@when("I build the v0.1.0 workbook model", target_fixture="workbook_model")
+def build_v010_workbook_model(source_fixture: dict[str, Any]) -> ThreeStatementModel:
+    """Build the workbook-ready model from a source fixture."""
+    fixture = source_fixture["fixture"]
+    source = source_fixture["source"]
+    extracted = ExtractedData(
+        entity_name=str(fixture["entity_name"]),
+        periods=sample_periods(),
+        source_records=[source_record_from_dict(record, source) for record in fixture["records"]],
+        metadata={"source": source},
+    )
+    return ModelBuilder().build_three_statement_model(extracted)
+
+
+@then("the workbook has exactly the three expected statements")
+def workbook_has_three_expected_statements(workbook_model: ThreeStatementModel) -> None:
+    """Assert the model exposes only the expected v0.1.0 statements."""
+    assert [
+        workbook_model.income_statement.name,
+        workbook_model.balance_sheet.name,
+        workbook_model.cash_flow_statement.name,
+    ] == ["Income Statement", "Balance Sheet", "Cash Flow Statement"]
+
+
+@then(parsers.parse("the {period} income statement reports net income of {amount:d}"))
+def income_statement_reports_net_income(
+    workbook_model: ThreeStatementModel,
+    period: str,
+    amount: int,
+) -> None:
+    """Assert the income statement net income outcome."""
+    assert _line_value(workbook_model.income_statement.lines, "Net Income", period) == Decimal(amount)
+
+
+@then(parsers.parse("the {period} income statement reports revenue of {amount:d}"))
+def income_statement_reports_revenue(
+    workbook_model: ThreeStatementModel,
+    period: str,
+    amount: int,
+) -> None:
+    """Assert the income statement revenue outcome."""
+    assert _line_value(workbook_model.income_statement.lines, "Revenue", period) == Decimal(amount)
+
+
+@then(parsers.parse("the {period} balance sheet balance check is zero"))
+def balance_sheet_balance_check_is_zero(workbook_model: ThreeStatementModel, period: str) -> None:
+    """Assert the balance sheet check outcome."""
+    assert _line_value(workbook_model.balance_sheet.lines, "Balance Check", period) == Decimal("0")
+
+
+@then(parsers.parse("the {period} cash flow tie-out is zero"))
+def cash_flow_tie_out_is_zero(workbook_model: ThreeStatementModel, period: str) -> None:
+    """Assert the cash flow statement tie-out outcome."""
+    assert _line_value(workbook_model.cash_flow_statement.lines, "Cash Flow Tie-Out", period) == Decimal(
+        "0"
+    )
+
+
+@then("the model has no error-level validation issues")
+def model_has_no_error_level_validation_issues(workbook_model: ThreeStatementModel) -> None:
+    """Assert that validation did not produce blocking issues."""
+    assert all(issue.severity != IssueSeverity.ERROR for issue in workbook_model.validation_issues)
+
+
+def _line_value(lines: list[StatementLine], label: str, period: str) -> Decimal:
+    for line in lines:
+        if line.label == label:
+            return line.values[period]
+    raise AssertionError(f"Missing statement line {label!r}")

--- a/tests/fixtures/sample_data.py
+++ b/tests/fixtures/sample_data.py
@@ -1,9 +1,12 @@
 """Sample data fixtures for testing."""
 
+from __future__ import annotations
+
 from datetime import date
 from decimal import Decimal
+from typing import Any
 
-from waccy.core.models import ExtractedData, ExtractedTransaction
+from waccy.core.models import ExtractedData, ExtractedTransaction, PeriodType, ReportingPeriod
 
 
 def sample_transaction() -> ExtractedTransaction:
@@ -27,3 +30,155 @@ def sample_extracted_data() -> ExtractedData:
         quality_score=0.9,
     )
 
+
+def sample_periods() -> list[ReportingPeriod]:
+    """Create annual fixture periods."""
+    return [
+        ReportingPeriod(
+            label="2023",
+            start_date=date(2023, 1, 1),
+            end_date=date(2023, 12, 31),
+            period_type=PeriodType.YEAR,
+        ),
+        ReportingPeriod(
+            label="2024",
+            start_date=date(2024, 1, 1),
+            end_date=date(2024, 12, 31),
+            period_type=PeriodType.YEAR,
+        ),
+    ]
+
+
+def sample_qbo_fixture() -> dict[str, Any]:
+    """Create a balanced QBO-like fixture."""
+    return {
+        "entity_name": "Fixture Co",
+        "periods": [
+            {"label": "2023", "start_date": "2023-01-01", "end_date": "2023-12-31"},
+            {"label": "2024", "start_date": "2024-01-01", "end_date": "2024-12-31"},
+        ],
+        "records": _records(
+            names={
+                "revenue": "Sales",
+                "cogs": "Cost of Goods Sold",
+                "opex": "Operating Expenses",
+                "da": "Depreciation",
+                "interest": "Interest Expense",
+                "tax": "Income Tax Expense",
+                "cash": "Checking",
+                "ar": "Accounts Receivable",
+                "inventory": "Inventory",
+                "ppe": "Fixed Assets",
+                "acc_dep": "Accumulated Depreciation",
+                "ap": "Accounts Payable",
+                "accrued": "Accrued Expenses",
+                "debt": "Notes Payable",
+                "equity": "Owners Equity",
+                "retained": "Retained Earnings",
+                "da_addback": "Depreciation Addback",
+                "wc": "Change in Working Capital",
+                "capex": "Capital Expenditures",
+                "financing": "Debt Proceeds",
+            }
+        ),
+    }
+
+
+def sample_edgar_fixture() -> dict[str, Any]:
+    """Create a balanced EDGAR/XBRL-like fixture."""
+    return {
+        "entity_name": "Fixture Co",
+        "cik": "0000000000",
+        "periods": [
+            {"label": "2023", "start_date": "2023-01-01", "end_date": "2023-12-31"},
+            {"label": "2024", "start_date": "2024-01-01", "end_date": "2024-12-31"},
+        ],
+        "records": _records(
+            names={
+                "revenue": "us-gaap:Revenues",
+                "cogs": "us-gaap:CostOfRevenue",
+                "opex": "us-gaap:SellingGeneralAndAdministrativeExpense",
+                "da": "us-gaap:DepreciationDepletionAndAmortization",
+                "interest": "us-gaap:InterestExpense",
+                "tax": "us-gaap:IncomeTaxExpenseBenefit",
+                "cash": "us-gaap:CashAndCashEquivalentsAtCarryingValue",
+                "ar": "us-gaap:AccountsReceivableNetCurrent",
+                "inventory": "us-gaap:InventoryNet",
+                "ppe": "us-gaap:PropertyPlantAndEquipmentNet",
+                "acc_dep": "us-gaap:AccumulatedDepreciationDepletionAndAmortizationPropertyPlantAndEquipment",
+                "ap": "us-gaap:AccountsPayableCurrent",
+                "accrued": "us-gaap:AccruedLiabilitiesCurrent",
+                "debt": "us-gaap:LongTermDebtNoncurrent",
+                "equity": "us-gaap:StockholdersEquity",
+                "retained": "us-gaap:RetainedEarningsAccumulatedDeficit",
+                "da_addback": "Depreciation And Amortization",
+                "wc": "Changes In Operating Assets And Liabilities",
+                "capex": "us-gaap:PaymentsToAcquirePropertyPlantAndEquipment",
+                "financing": "us-gaap:ProceedsFromIssuanceOfLongTermDebt",
+            }
+        ),
+    }
+
+
+def _records(names: dict[str, str]) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    records.extend(
+        [
+            _record(names["revenue"], "2023", 1000, "income_statement"),
+            _record(names["cogs"], "2023", 400, "income_statement"),
+            _record(names["opex"], "2023", 200, "income_statement"),
+            _record(names["da"], "2023", 50, "income_statement"),
+            _record(names["interest"], "2023", 20, "income_statement"),
+            _record(names["tax"], "2023", 66, "income_statement"),
+            _record(names["revenue"], "2024", 1200, "income_statement"),
+            _record(names["cogs"], "2024", 480, "income_statement"),
+            _record(names["opex"], "2024", 240, "income_statement"),
+            _record(names["da"], "2024", 60, "income_statement"),
+            _record(names["interest"], "2024", 25, "income_statement"),
+            _record(names["tax"], "2024", 79, "income_statement"),
+        ]
+    )
+    records.extend(
+        [
+            _record(names["cash"], "2023", 100, "balance_sheet"),
+            _record(names["ar"], "2023", 150, "balance_sheet"),
+            _record(names["inventory"], "2023", 100, "balance_sheet"),
+            _record(names["ppe"], "2023", 500, "balance_sheet"),
+            _record(names["acc_dep"], "2023", 50, "balance_sheet"),
+            _record(names["ap"], "2023", 120, "balance_sheet"),
+            _record(names["accrued"], "2023", 80, "balance_sheet"),
+            _record(names["debt"], "2023", 300, "balance_sheet"),
+            _record(names["equity"], "2023", 36, "balance_sheet"),
+            _record(names["retained"], "2023", 264, "balance_sheet"),
+            _record(names["cash"], "2024", 380, "balance_sheet"),
+            _record(names["ar"], "2024", 180, "balance_sheet"),
+            _record(names["inventory"], "2024", 120, "balance_sheet"),
+            _record(names["ppe"], "2024", 600, "balance_sheet"),
+            _record(names["acc_dep"], "2024", 110, "balance_sheet"),
+            _record(names["ap"], "2024", 140, "balance_sheet"),
+            _record(names["accrued"], "2024", 90, "balance_sheet"),
+            _record(names["debt"], "2024", 354, "balance_sheet"),
+            _record(names["equity"], "2024", 270, "balance_sheet"),
+            _record(names["retained"], "2024", 316, "balance_sheet"),
+        ]
+    )
+    records.extend(
+        [
+            _record(names["da_addback"], "2024", 60, "cash_flow_statement"),
+            _record(names["wc"], "2024", -50, "cash_flow_statement"),
+            _record(names["capex"], "2024", -100, "cash_flow_statement"),
+            _record(names["financing"], "2024", 54, "cash_flow_statement"),
+        ]
+    )
+    return records
+
+
+def _record(name: str, period: str, amount: int, statement: str) -> dict[str, Any]:
+    return {
+        "source_account_id": name,
+        "source_account_name": name,
+        "name": name,
+        "period": period,
+        "amount": amount,
+        "statement": statement,
+    }

--- a/tests/unit/test_supporting_modules.py
+++ b/tests/unit/test_supporting_modules.py
@@ -184,8 +184,10 @@ def test_validation_reports_mapped_records_without_account_ids() -> None:
         ],
     )
     validated = DataMapper().validate(mapped)
+    issue_codes = {issue.code for issue in validated.issues}
 
-    assert "missing_mapped_account_id" in {issue.code for issue in validated.issues}
+    assert "missing_mapped_account_id" in issue_codes
+    assert "mapping_overridden" not in issue_codes
     assert not validated.is_valid
 
 

--- a/tests/unit/test_supporting_modules.py
+++ b/tests/unit/test_supporting_modules.py
@@ -15,6 +15,8 @@ from waccy.core.models import (
     ExtractedData,
     IssueSeverity,
     MappedFinancialDataset,
+    MappedFinancialRecord,
+    MappingStatus,
     ReportingPeriod,
     SourceRecord,
     SourceReference,
@@ -117,7 +119,7 @@ def test_quality_report_covers_empty_and_partial_legacy_transactions() -> None:
     assert empty_report["avg_confidence"] == 1.0
     assert empty_report["issues"] == ["No source records or transactions were extracted."]
 
-    extracted = sample_extracted_data()
+    extracted = sample_extracted_data().model_copy(deep=True)
     extracted.transactions[0].account_id = ""
     report = extracted.generate_quality_report()
 
@@ -161,6 +163,32 @@ def test_validation_branches_for_period_ranges_and_empty_dataset() -> None:
     assert not validated.is_valid
 
 
+def test_validation_reports_mapped_records_without_account_ids() -> None:
+    """Validation rejects mapped statuses that lack canonical account IDs."""
+    source = SourceRecord(
+        source_account_id="sales",
+        source_account_name="Sales",
+        amount=Decimal("1"),
+        period_label="2024",
+        source=SourceReference(source_system="qbo", source_id="sales", source_label="Sales"),
+    )
+    mapped = MappedFinancialDataset(
+        entity_name="Fixture",
+        periods=[sample_periods()[1]],
+        records=[
+            MappedFinancialRecord(
+                source_record=source,
+                status=MappingStatus.MAPPED,
+                confidence=0.95,
+            )
+        ],
+    )
+    validated = DataMapper().validate(mapped)
+
+    assert "missing_mapped_account_id" in {issue.code for issue in validated.issues}
+    assert not validated.is_valid
+
+
 def test_model_builder_accepts_validated_and_mapped_inputs(tmp_path: Path) -> None:
     """ModelBuilder handles all public input layers and export helper."""
     fixture = sample_qbo_fixture()
@@ -186,9 +214,26 @@ def test_model_builder_accepts_validated_and_mapped_inputs(tmp_path: Path) -> No
 
 
 def test_model_builder_reports_missing_required_statement_line() -> None:
-    """Missing computed statement lines fail loudly for developer mistakes."""
+    """Missing computed statement lines fail loudly through public model building."""
+    fixture = sample_qbo_fixture()
+    extracted = ExtractedData(
+        entity_name="Fixture Co",
+        periods=sample_periods(),
+        source_records=[source_record_from_dict(record, "qbo") for record in fixture["records"]],
+        metadata={"source": "qbo"},
+    )
+
+    class BrokenModelBuilder(ModelBuilder):
+        def _build_income_statement_lines(
+            self,
+            records: list[MappedFinancialRecord],
+            period_labels: list[str],
+        ) -> list:
+            del records, period_labels
+            return []
+
     with pytest.raises(ValueError, match="Missing statement line"):
-        ModelBuilder()._find_line([], "Net Income")
+        BrokenModelBuilder().build_three_statement_model(extracted)
 
 
 def test_validated_dataset_is_invalid_when_error_issue_exists() -> None:

--- a/tests/unit/test_supporting_modules.py
+++ b/tests/unit/test_supporting_modules.py
@@ -1,0 +1,222 @@
+"""Coverage for small support modules and edge branches."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from typing import TYPE_CHECKING
+
+import pytest
+
+from tests.fixtures.sample_data import sample_extracted_data, sample_periods, sample_qbo_fixture
+from waccy.classification import ClassificationEngine, ConfidenceScorer, PatternMatcher
+from waccy.cli import main
+from waccy.core.models import (
+    ExtractedData,
+    IssueSeverity,
+    MappedFinancialDataset,
+    ReportingPeriod,
+    SourceRecord,
+    SourceReference,
+    ValidatedFinancialDataset,
+    ValidationIssue,
+)
+from waccy.core.ontology import AccountType, StandardChartOfAccounts
+from waccy.core.validation import validate_extracted_data
+from waccy.extraction.base import Extractor
+from waccy.extraction.mapper import DataMapper, source_record_from_dict
+from waccy.extraction.registry import ExtractorRegistry
+from waccy.modeling import ModelBuilder, ModelTemplate
+from waccy.utils import format_currency, format_date, format_percentage, parse_date_range
+from waccy.utils.dates import validate_date_range as validate_date_range_util
+from waccy.utils.validation import validate_amount
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_cli_placeholder_returns_success(capsys: pytest.CaptureFixture[str]) -> None:
+    """The placeholder CLI exits successfully and prints API guidance."""
+    assert main([]) == 0
+    output = capsys.readouterr().out
+    assert "WACCY CLI" in output
+    assert "ModelBuilder" in output
+
+
+def test_utils_parse_format_and_validate_values() -> None:
+    """Utility helpers format and validate the simple supported cases."""
+    assert parse_date_range(("2024-01-01", "2024-12-31")) == (
+        date(2024, 1, 1),
+        date(2024, 12, 31),
+    )
+    assert format_date(date(2024, 1, 2)) == "2024-01-02"
+    assert validate_date_range_util(date(2024, 1, 1), date(2024, 1, 2))
+    assert format_currency(Decimal("1234.5")) == "USD 1,234.50"
+    assert format_percentage(0.1234, decimals=1) == "12.3%"
+    assert validate_amount(1.0)
+    assert validate_amount(1)
+    assert not validate_amount(float("nan"))
+    with pytest.raises(NotImplementedError):
+        parse_date_range("2024-01-01 to 2024-12-31")
+
+
+def test_classification_placeholders_have_stable_contracts() -> None:
+    """Classification scaffold methods keep their current API behavior."""
+    engine = ClassificationEngine(llm_provider="fixture")
+    assert engine.llm_provider == "fixture"
+    engine.learn_from_edgar({"filing": "fixture"})
+    with pytest.raises(NotImplementedError):
+        engine.classify_account("Sales", [], {})
+
+    assert ConfidenceScorer().calculate_confidence("Sales", "revenue", [], {}) == 0.0
+    matcher = PatternMatcher()
+    assert matcher.extract_patterns({"filing": "fixture"}) == {}
+    assert matcher.match_pattern("Sales", []) is None
+
+
+def test_model_template_placeholder_contract() -> None:
+    """ModelTemplate keeps placeholder structure behavior explicit."""
+    template = ModelTemplate("three_statement")
+    assert template.model_type == "three_statement"
+    assert template.get_structure() == {}
+    assert template.apply_template({"value": 1}) == {}
+
+
+def test_extractors_registry_and_base_validation() -> None:
+    """Registry registration and base validation work without installed extensions."""
+
+    class FixtureExtractor(Extractor):
+        @property
+        def name(self) -> str:
+            return "Fixture"
+
+        @property
+        def data_source(self) -> str:
+            return "fixture"
+
+        def authenticate(self, credentials: dict[str, str]) -> bool:
+            return bool(credentials)
+
+        def extract(self, config: dict[str, object]) -> ExtractedData:
+            return ExtractedData(metadata={"config": config})
+
+    registry = ExtractorRegistry()
+    registry.register_extractor("fixture", FixtureExtractor)
+
+    assert registry.get_extractor("fixture") is FixtureExtractor
+    assert "fixture" in registry.list_extractors()
+    assert registry.get_extractor("missing") is None
+    assert FixtureExtractor().validate(sample_extracted_data())
+    assert not validate_extracted_data(ExtractedData())
+
+
+def test_quality_report_covers_empty_and_partial_legacy_transactions() -> None:
+    """Quality reports surface empty datasets and partially mapped transactions."""
+    empty_report = ExtractedData().generate_quality_report()
+    assert empty_report["completeness"] == 0.0
+    assert empty_report["avg_confidence"] == 1.0
+    assert empty_report["issues"] == ["No source records or transactions were extracted."]
+
+    extracted = sample_extracted_data()
+    extracted.transactions[0].account_id = ""
+    report = extracted.generate_quality_report()
+
+    assert report["completeness"] == 1.0
+    assert report["avg_confidence"] == 0.95
+    assert "Some transactions are missing account mappings." in report["issues"]
+
+
+def test_ontology_filters_accounts_and_handles_missing_mappings() -> None:
+    """Ontology filtering and missing lookup branches are covered."""
+    ontology = StandardChartOfAccounts()
+
+    assert ontology.map_account("not a real account", "qbo") is None
+    assert ontology.get_account("not-real") is None
+    assert all(account.type == AccountType.ASSET for account in ontology.list_accounts(AccountType.ASSET))
+
+
+def test_mapper_creates_periods_for_legacy_transactions_and_handles_missing_names() -> None:
+    """The mapper supports transaction-only compatibility and sparse fixture dicts."""
+    normalized = DataMapper().normalize(sample_extracted_data())
+    assert [period.label for period in normalized.periods] == ["2024"]
+    assert normalized.records[0].source_account_id == "revenue-001"
+
+    record = source_record_from_dict({"account_id": "Sales", "period": "2024", "amount": 10}, "qbo")
+    assert record.source_account_id == "Sales"
+    assert record.source_account_name == "Sales"
+
+
+def test_validation_branches_for_period_ranges_and_empty_dataset() -> None:
+    """Validation reports invalid periods and empty mapped datasets."""
+    bad_period = ReportingPeriod(
+        label="bad",
+        start_date=date(2024, 12, 31),
+        end_date=date(2024, 1, 1),
+    )
+    mapped = MappedFinancialDataset(entity_name="Fixture", periods=[bad_period], records=[])
+    validated = DataMapper().validate(mapped)
+    issue_codes = {issue.code for issue in validated.issues}
+
+    assert {"invalid_period_range", "empty_dataset"}.issubset(issue_codes)
+    assert not validated.is_valid
+
+
+def test_model_builder_accepts_validated_and_mapped_inputs(tmp_path: Path) -> None:
+    """ModelBuilder handles all public input layers and export helper."""
+    fixture = sample_qbo_fixture()
+    extracted = ExtractedData(
+        entity_name="Fixture Co",
+        periods=sample_periods(),
+        source_records=[source_record_from_dict(record, "qbo") for record in fixture["records"]],
+        metadata={"source": "qbo"},
+    )
+    validated = DataMapper().map_to_standard(extracted)
+    builder = ModelBuilder()
+
+    mapped_model = builder.build_three_statement_model(validated.mapped_dataset)
+    validated_model = builder.build_three_statement_model(validated)
+    output_path = tmp_path / "model.xlsx"
+    builder.export_to_sheets(mapped_model, str(output_path))
+
+    assert mapped_model.entity_name == "Fixture Co"
+    assert validated_model.entity_name == "Fixture Co"
+    assert output_path.exists()
+    with pytest.raises(NotImplementedError):
+        builder.build_dcf_model(mapped_model, 0.1, 0.03, 10.0)
+
+
+def test_model_builder_reports_missing_required_statement_line() -> None:
+    """Missing computed statement lines fail loudly for developer mistakes."""
+    with pytest.raises(ValueError, match="Missing statement line"):
+        ModelBuilder()._find_line([], "Net Income")
+
+
+def test_validated_dataset_is_invalid_when_error_issue_exists() -> None:
+    """Validated datasets distinguish warning/info issues from errors."""
+    source = SourceRecord(
+        source_account_id="sales",
+        source_account_name="Sales",
+        amount=Decimal("1"),
+        period_label="2024",
+        source=SourceReference(source_system="qbo", source_id="sales", source_label="Sales"),
+    )
+    mapped = DataMapper().map_dataset(
+        DataMapper().normalize(
+            ExtractedData(
+                entity_name="Fixture",
+                periods=sample_periods(),
+                source_records=[source],
+            )
+        )
+    )
+    warning_only = ValidatedFinancialDataset(
+        mapped_dataset=mapped,
+        issues=[ValidationIssue(code="warning", message="warning", severity=IssueSeverity.WARNING)],
+    )
+    error = ValidatedFinancialDataset(
+        mapped_dataset=mapped,
+        issues=[ValidationIssue(code="error", message="error", severity=IssueSeverity.ERROR)],
+    )
+
+    assert warning_only.is_valid
+    assert not error.is_valid

--- a/tests/unit/test_v010_pipeline.py
+++ b/tests/unit/test_v010_pipeline.py
@@ -152,6 +152,10 @@ def test_qbo_fixture_extractor_rejects_invalid_fixture_shapes() -> None:
         extractor.extract({"fixture": {"records": "not-a-list"}})
     with pytest.raises(ValueError, match="records must be dictionaries"):
         extractor.extract({"fixture": {"records": ["not-a-dict"]}})
+    with pytest.raises(ValueError, match="accounts must be a list"):
+        extractor.extract({"fixture": {"records": [], "accounts": "not-a-list"}})
+    with pytest.raises(ValueError, match="accounts must be dictionaries"):
+        extractor.extract({"fixture": {"records": [], "accounts": ["not-a-dict"]}})
 
 
 def test_edgar_fixture_extractor_produces_normalized_dataset() -> None:
@@ -185,6 +189,8 @@ def test_edgar_fixture_extractor_rejects_invalid_fixture_shapes() -> None:
         extractor.extract({"fixture": {"records": "not-a-list"}})
     with pytest.raises(ValueError, match="records must be dictionaries"):
         extractor.extract({"fixture": {"records": ["not-a-dict"]}})
+    with pytest.raises(ValueError, match="periods must be dictionaries"):
+        extractor.extract({"fixture": {"records": [], "periods": ["not-a-dict"]}})
 
 
 def test_validation_reports_unmapped_missing_periods_and_duplicate_periods() -> None:
@@ -245,17 +251,19 @@ def test_xlsx_export_writes_three_sheet_workbook(tmp_path: Path) -> None:
 
     SheetExporter().export(model, str(output_path))
     workbook = load_workbook(output_path)
-
-    assert workbook.sheetnames == ["Income Statement", "Balance Sheet", "Cash Flow Statement"]
-    income_statement = workbook["Income Statement"]
-    balance_sheet = workbook["Balance Sheet"]
-    cash_flow_statement = workbook["Cash Flow Statement"]
-    assert income_statement["B1"].value == "2023"
-    assert income_statement["C11"].value == 316
-    assert balance_sheet["A15"].value == "Balance Check"
-    assert balance_sheet["C15"].value == 0
-    assert cash_flow_statement["A8"].value == "Cash Flow Tie-Out"
-    assert cash_flow_statement["C8"].value == 0
+    try:
+        assert workbook.sheetnames == ["Income Statement", "Balance Sheet", "Cash Flow Statement"]
+        income_statement = workbook["Income Statement"]
+        balance_sheet = workbook["Balance Sheet"]
+        cash_flow_statement = workbook["Cash Flow Statement"]
+        assert income_statement["B1"].value == "2023"
+        assert income_statement["C11"].value == 316
+        assert balance_sheet["A15"].value == "Balance Check"
+        assert balance_sheet["C15"].value == 0
+        assert cash_flow_statement["A8"].value == "Cash Flow Tie-Out"
+        assert cash_flow_statement["C8"].value == 0
+    finally:
+        workbook.close()
 
 
 def _source_record(account_id: str, account_name: str) -> SourceRecord:
@@ -284,6 +292,8 @@ def _extracted(fixture: dict[str, object], source_system: str) -> ExtractedData:
 def _line_value(lines: list[object], label: str, period: str) -> Decimal:
     for line in lines:
         if line.label == label:
+            if period not in line.values:
+                raise AssertionError(f"Line {label!r} is missing period {period!r}")
             return line.values[period]
     raise AssertionError(f"Missing line {label!r}")
 

--- a/tests/unit/test_v010_pipeline.py
+++ b/tests/unit/test_v010_pipeline.py
@@ -1,0 +1,267 @@
+"""Fixture-first v0.1.0 financial model pipeline tests."""
+
+from __future__ import annotations
+
+import importlib.util
+from decimal import Decimal
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+from openpyxl import load_workbook
+
+from tests.fixtures.sample_data import sample_edgar_fixture, sample_periods, sample_qbo_fixture
+from waccy.core.models import (
+    ExtractedData,
+    IssueSeverity,
+    MappedFinancialDataset,
+    MappingOverride,
+    MappingStatus,
+    NormalizedFinancialDataset,
+    SourceRecord,
+    SourceReference,
+    ValidatedFinancialDataset,
+)
+from waccy.core.ontology import StandardChartOfAccounts
+from waccy.core.validation import validate_mapped_dataset
+from waccy.extraction.mapper import DataMapper, source_record_from_dict
+from waccy.modeling.builder import ModelBuilder
+from waccy.modeling.exporters import SheetExporter
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_core_dataset_models_round_trip() -> None:
+    """Core data models carry normalized, mapped, and validated layers."""
+    period = sample_periods()[0]
+    source = SourceRecord(
+        source_account_id="sales",
+        source_account_name="Sales",
+        amount=Decimal("100"),
+        period_label=period.label,
+        source=SourceReference(source_system="qbo", source_id="sales", source_label="Sales"),
+    )
+    normalized = NormalizedFinancialDataset(
+        entity_name="Fixture Co",
+        periods=[period],
+        records=[source],
+    )
+    mapped = DataMapper().map_dataset(normalized)
+    validated = validate_mapped_dataset(mapped)
+
+    assert isinstance(mapped, MappedFinancialDataset)
+    assert isinstance(validated, ValidatedFinancialDataset)
+    assert validated.is_valid
+    assert mapped.records[0].status == MappingStatus.MAPPED
+
+
+def test_ontology_contains_required_accounts_and_aliases() -> None:
+    """The v0.1.0 ontology includes model lines and source aliases."""
+    ontology = StandardChartOfAccounts()
+    required = {
+        "revenue",
+        "cogs",
+        "operating_expenses",
+        "depreciation_amortization",
+        "interest_expense",
+        "tax_expense",
+        "cash",
+        "accounts_receivable",
+        "inventory",
+        "ppe",
+        "accumulated_depreciation",
+        "accounts_payable",
+        "accrued_expenses",
+        "debt",
+        "equity",
+        "retained_earnings",
+        "net_income",
+        "depreciation_addback",
+        "working_capital_movement",
+        "capex",
+        "financing_movement",
+    }
+
+    assert required.issubset(ontology.accounts)
+    assert ontology.map_account("Sales", "qbo").id == "revenue"
+    assert ontology.map_account("us-gaap:Revenues", "edgar").id == "revenue"
+    assert ontology.map_account("us-gaap:CashAndCashEquivalentsAtCarryingValue", "edgar").id == "cash"
+
+
+def test_mapper_statuses_for_mapped_ambiguous_overridden_and_unmapped() -> None:
+    """The mapper emits all review states required by the API-first workflow."""
+    ontology = StandardChartOfAccounts()
+    ontology._aliases["ambiguous"] = ["revenue", "cogs"]
+    mapper = DataMapper(ontology)
+    period = sample_periods()[0]
+    dataset = NormalizedFinancialDataset(
+        entity_name="Fixture Co",
+        periods=[period],
+        records=[
+            _source_record("sales", "Sales"),
+            _source_record("ambiguous", "ambiguous"),
+            _source_record("manual", "Manual Account"),
+            _source_record("mystery", "Mystery Account"),
+        ],
+    )
+
+    mapped = mapper.map_dataset(
+        dataset,
+        overrides={"manual": MappingOverride(account_id="cash", note="Known bank account")},
+    )
+    statuses = {record.source_record.source_account_id: record.status for record in mapped.records}
+
+    assert statuses == {
+        "sales": MappingStatus.MAPPED,
+        "ambiguous": MappingStatus.AMBIGUOUS,
+        "manual": MappingStatus.OVERRIDDEN,
+        "mystery": MappingStatus.UNMAPPED,
+    }
+
+
+def test_qbo_fixture_extractor_produces_normalized_dataset() -> None:
+    """The QBO extractor accepts fixture/dict input and normalizes it."""
+    extractor_class = _load_extension_class(
+        ROOT / "extensions" / "waccy-quickbooks" / "src" / "waccy_quickbooks" / "extractor.py",
+        "local_waccy_quickbooks_extractor",
+        "QuickBooksExtractor",
+    )
+
+    extracted = extractor_class().extract({"fixture": sample_qbo_fixture()})
+    normalized = DataMapper().normalize(extracted)
+
+    assert normalized.entity_name == "Fixture Co"
+    assert len(normalized.periods) == 2
+    assert len(normalized.records) == len(sample_qbo_fixture()["records"])
+    assert {record.source.source_system for record in normalized.records} == {"qbo"}
+
+
+def test_edgar_fixture_extractor_produces_normalized_dataset() -> None:
+    """The EDGAR extractor accepts XBRL-like fixture/dict input and normalizes it."""
+    extractor_class = _load_extension_class(
+        ROOT / "extensions" / "waccy-edgar" / "src" / "waccy_edgar" / "extractor.py",
+        "local_waccy_edgar_extractor",
+        "EdgarExtractor",
+    )
+
+    extracted = extractor_class().extract({"fixture": sample_edgar_fixture()})
+    normalized = DataMapper().normalize(extracted)
+
+    assert normalized.entity_name == "Fixture Co"
+    assert len(normalized.periods) == 2
+    assert normalized.records[0].source.source_system == "edgar"
+
+
+def test_validation_reports_unmapped_missing_periods_and_duplicate_periods() -> None:
+    """Validation catches unmapped records and period defects."""
+    period = sample_periods()[0]
+    source = _source_record("mystery", "Mystery Account")
+    dataset = NormalizedFinancialDataset(
+        entity_name="Fixture Co",
+        periods=[period, period],
+        records=[source_record_from_dict({"name": "Sales", "period": "2025", "amount": 1}, "qbo"), source],
+    )
+    mapped = DataMapper().map_dataset(dataset)
+    validated = validate_mapped_dataset(mapped)
+    issue_codes = {issue.code for issue in validated.issues}
+
+    assert {"duplicate_period", "missing_period", "unmapped_account"}.issubset(issue_codes)
+    assert not validated.is_valid
+
+
+def test_model_builder_reports_balance_and_cash_flow_issues() -> None:
+    """Model validation includes balance-sheet and cash-flow checks."""
+    fixture = sample_qbo_fixture()
+    fixture["records"] = [
+        *fixture["records"],
+        {"name": "Checking", "period": "2024", "amount": 1, "statement": "balance_sheet"},
+    ]
+    extracted = ExtractedData(
+        entity_name="Fixture Co",
+        periods=sample_periods(),
+        source_records=[source_record_from_dict(record, "qbo") for record in fixture["records"]],
+        metadata={"source": "qbo"},
+    )
+    model = ModelBuilder().build_three_statement_model(extracted)
+    issue_codes = {issue.code for issue in model.validation_issues}
+
+    assert "balance_sheet_imbalance" in issue_codes
+    assert "cash_flow_tie_out_failure" in issue_codes
+
+
+def test_model_builder_builds_qbo_and_edgar_three_statement_models() -> None:
+    """QBO and EDGAR fixtures both build the source-agnostic model."""
+    builder = ModelBuilder()
+    qbo_model = builder.build_three_statement_model(_extracted(sample_qbo_fixture(), "qbo"))
+    edgar_model = builder.build_three_statement_model(_extracted(sample_edgar_fixture(), "edgar"))
+
+    assert _line_value(qbo_model.income_statement.lines, "Net Income", "2024") == Decimal("316")
+    assert _line_value(qbo_model.balance_sheet.lines, "Balance Check", "2024") == Decimal("0")
+    assert _line_value(qbo_model.cash_flow_statement.lines, "Cash Flow Tie-Out", "2024") == Decimal("0")
+    assert _line_value(edgar_model.income_statement.lines, "Revenue", "2024") == Decimal("1200")
+    assert all(issue.severity != IssueSeverity.ERROR for issue in qbo_model.validation_issues)
+    assert all(issue.severity != IssueSeverity.ERROR for issue in edgar_model.validation_issues)
+
+
+def test_xlsx_export_writes_three_sheet_workbook(tmp_path: Path) -> None:
+    """The XLSX exporter writes three formatted statement sheets."""
+    model = ModelBuilder().build_three_statement_model(_extracted(sample_qbo_fixture(), "qbo"))
+    output_path = tmp_path / "fixture-model.xlsx"
+
+    SheetExporter().export(model, str(output_path))
+    workbook = load_workbook(output_path)
+
+    assert workbook.sheetnames == ["Income Statement", "Balance Sheet", "Cash Flow Statement"]
+    income_statement = workbook["Income Statement"]
+    balance_sheet = workbook["Balance Sheet"]
+    cash_flow_statement = workbook["Cash Flow Statement"]
+    assert income_statement["B1"].value == "2023"
+    assert income_statement["C11"].value == 316
+    assert balance_sheet["A15"].value == "Balance Check"
+    assert balance_sheet["C15"].value == 0
+    assert cash_flow_statement["A8"].value == "Cash Flow Tie-Out"
+    assert cash_flow_statement["C8"].value == 0
+
+
+def _source_record(account_id: str, account_name: str) -> SourceRecord:
+    return SourceRecord(
+        source_account_id=account_id,
+        source_account_name=account_name,
+        amount=Decimal("100"),
+        period_label="2023",
+        source=SourceReference(source_system="fixture", source_id=account_id, source_label=account_name),
+    )
+
+
+def _extracted(fixture: dict[str, object], source_system: str) -> ExtractedData:
+    return ExtractedData(
+        entity_name=str(fixture["entity_name"]),
+        periods=sample_periods(),
+        source_records=[
+            source_record_from_dict(record, source_system)
+            for record in fixture["records"]
+            if isinstance(record, dict)
+        ],
+        metadata={"source": source_system},
+    )
+
+
+def _line_value(lines: list[object], label: str, period: str) -> Decimal:
+    for line in lines:
+        if line.label == label:
+            return line.values[period]
+    raise AssertionError(f"Missing line {label!r}")
+
+
+def _load_extension_class(path: Path, module_name: str, class_name: str) -> type[Any]:
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    if spec is None or spec.loader is None:
+        raise AssertionError(f"Could not load extension module from {path}")
+    module = importlib.util.module_from_spec(spec)
+    if not isinstance(module, ModuleType):
+        raise AssertionError(f"Could not create extension module from {path}")
+    spec.loader.exec_module(module)
+    loaded_class = getattr(module, class_name)
+    if not isinstance(loaded_class, type):
+        raise AssertionError(f"{class_name} is not a class")
+    return loaded_class

--- a/tests/unit/test_v010_pipeline.py
+++ b/tests/unit/test_v010_pipeline.py
@@ -156,6 +156,8 @@ def test_qbo_fixture_extractor_rejects_invalid_fixture_shapes() -> None:
         extractor.extract({"fixture": {"records": ["not-a-dict"]}})
     with pytest.raises(ValueError, match="periods must be dictionaries"):
         extractor.extract({"fixture": {"records": [], "periods": ["not-a-dict"]}})
+    with pytest.raises(ValueError, match="missing required keys: end_date"):
+        extractor.extract({"fixture": {"records": [], "periods": [{"label": "2024", "start_date": "2024-01-01"}]}})
     with pytest.raises(ValueError, match="accounts must be a list"):
         extractor.extract({"fixture": {"records": [], "accounts": "not-a-list"}})
     with pytest.raises(ValueError, match="accounts must be dictionaries"):
@@ -197,6 +199,8 @@ def test_edgar_fixture_extractor_rejects_invalid_fixture_shapes() -> None:
         extractor.extract({"fixture": {"records": ["not-a-dict"]}})
     with pytest.raises(ValueError, match="periods must be dictionaries"):
         extractor.extract({"fixture": {"records": [], "periods": ["not-a-dict"]}})
+    with pytest.raises(ValueError, match="missing required keys: end_date"):
+        extractor.extract({"fixture": {"records": [], "periods": [{"label": "2024", "start_date": "2024-01-01"}]}})
 
 
 def test_validation_reports_unmapped_missing_periods_and_duplicate_periods() -> None:

--- a/tests/unit/test_v010_pipeline.py
+++ b/tests/unit/test_v010_pipeline.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from types import ModuleType
 from typing import Any
 
+import pytest
 from openpyxl import load_workbook
 
 from tests.fixtures.sample_data import sample_edgar_fixture, sample_periods, sample_qbo_fixture
@@ -136,6 +137,23 @@ def test_qbo_fixture_extractor_produces_normalized_dataset() -> None:
     assert {record.source.source_system for record in normalized.records} == {"qbo"}
 
 
+def test_qbo_fixture_extractor_rejects_invalid_fixture_shapes() -> None:
+    """The QBO extractor returns clear errors for invalid fixture shapes."""
+    extractor_class = _load_extension_class(
+        ROOT / "extensions" / "waccy-quickbooks" / "src" / "waccy_quickbooks" / "extractor.py",
+        "local_waccy_quickbooks_extractor_invalid",
+        "QuickBooksExtractor",
+    )
+    extractor = extractor_class()
+
+    with pytest.raises(ValueError, match="dictionary payload"):
+        extractor.extract({"fixture": "not-a-dict"})
+    with pytest.raises(ValueError, match="'records' list"):
+        extractor.extract({"fixture": {"records": "not-a-list"}})
+    with pytest.raises(ValueError, match="records must be dictionaries"):
+        extractor.extract({"fixture": {"records": ["not-a-dict"]}})
+
+
 def test_edgar_fixture_extractor_produces_normalized_dataset() -> None:
     """The EDGAR extractor accepts XBRL-like fixture/dict input and normalizes it."""
     extractor_class = _load_extension_class(
@@ -150,6 +168,23 @@ def test_edgar_fixture_extractor_produces_normalized_dataset() -> None:
     assert normalized.entity_name == "Fixture Co"
     assert len(normalized.periods) == 2
     assert normalized.records[0].source.source_system == "edgar"
+
+
+def test_edgar_fixture_extractor_rejects_invalid_fixture_shapes() -> None:
+    """The EDGAR extractor returns clear errors for invalid fixture shapes."""
+    extractor_class = _load_extension_class(
+        ROOT / "extensions" / "waccy-edgar" / "src" / "waccy_edgar" / "extractor.py",
+        "local_waccy_edgar_extractor_invalid",
+        "EdgarExtractor",
+    )
+    extractor = extractor_class()
+
+    with pytest.raises(ValueError, match="dictionary payload"):
+        extractor.extract({"fixture": "not-a-dict"})
+    with pytest.raises(ValueError, match="'records' list"):
+        extractor.extract({"fixture": {"records": "not-a-list"}})
+    with pytest.raises(ValueError, match="records must be dictionaries"):
+        extractor.extract({"fixture": {"records": ["not-a-dict"]}})
 
 
 def test_validation_reports_unmapped_missing_periods_and_duplicate_periods() -> None:

--- a/tests/unit/test_v010_pipeline.py
+++ b/tests/unit/test_v010_pipeline.py
@@ -149,9 +149,13 @@ def test_qbo_fixture_extractor_rejects_invalid_fixture_shapes() -> None:
     with pytest.raises(ValueError, match="dictionary payload"):
         extractor.extract({"fixture": "not-a-dict"})
     with pytest.raises(ValueError, match="'records' list"):
+        extractor.extract({"fixture": {}, "records": []})
+    with pytest.raises(ValueError, match="'records' list"):
         extractor.extract({"fixture": {"records": "not-a-list"}})
     with pytest.raises(ValueError, match="records must be dictionaries"):
         extractor.extract({"fixture": {"records": ["not-a-dict"]}})
+    with pytest.raises(ValueError, match="periods must be dictionaries"):
+        extractor.extract({"fixture": {"records": [], "periods": ["not-a-dict"]}})
     with pytest.raises(ValueError, match="accounts must be a list"):
         extractor.extract({"fixture": {"records": [], "accounts": "not-a-list"}})
     with pytest.raises(ValueError, match="accounts must be dictionaries"):
@@ -185,6 +189,8 @@ def test_edgar_fixture_extractor_rejects_invalid_fixture_shapes() -> None:
 
     with pytest.raises(ValueError, match="dictionary payload"):
         extractor.extract({"fixture": "not-a-dict"})
+    with pytest.raises(ValueError, match="'records' list"):
+        extractor.extract({"fixture": {}, "records": []})
     with pytest.raises(ValueError, match="'records' list"):
         extractor.extract({"fixture": {"records": "not-a-list"}})
     with pytest.raises(ValueError, match="records must be dictionaries"):
@@ -277,14 +283,19 @@ def _source_record(account_id: str, account_name: str) -> SourceRecord:
 
 
 def _extracted(fixture: dict[str, object], source_system: str) -> ExtractedData:
+    raw_records = fixture["records"]
+    if not isinstance(raw_records, list):
+        raise AssertionError(f"Fixture {fixture['entity_name']!r} records must be a list.")
+    for record in raw_records:
+        if not isinstance(record, dict):
+            raise AssertionError(
+                f"Fixture {fixture['entity_name']!r} records must be dictionaries: {record!r}"
+            )
+
     return ExtractedData(
         entity_name=str(fixture["entity_name"]),
         periods=sample_periods(),
-        source_records=[
-            source_record_from_dict(record, source_system)
-            for record in fixture["records"]
-            if isinstance(record, dict)
-        ],
+        source_records=[source_record_from_dict(record, source_system) for record in raw_records],
         metadata={"source": source_system},
     )
 

--- a/uv.lock
+++ b/uv.lock
@@ -94,6 +94,24 @@ wheels = [
 ]
 
 [[package]]
+name = "et-xmlfile"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/38/af70d7ab1ae9d4da450eeec1fa3918940a5fafb9055e934af8d6eb0c2313/et_xmlfile-2.0.0.tar.gz", hash = "sha256:dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54", size = 17234, upload-time = "2024-10-25T17:25:40.039Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl", hash = "sha256:7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa", size = 18059, upload-time = "2024-10-25T17:25:39.051Z" },
+]
+
+[[package]]
+name = "gherkin-official"
+version = "29.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/d8/7a28537efd7638448f7512a0cce011d4e3bf1c7f4794ad4e9c87b3f1e98e/gherkin_official-29.0.0.tar.gz", hash = "sha256:dbea32561158f02280d7579d179b019160d072ce083197625e2f80a6776bb9eb", size = 32303, upload-time = "2024-08-12T09:41:09.595Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/fc/b86c22ad3b18d8324a9d6fe5a3b55403291d2bf7572ba6a16efa5aa88059/gherkin_official-29.0.0-py3-none-any.whl", hash = "sha256:26967b0d537a302119066742669e0e8b663e632769330be675457ae993e1d1bc", size = 37085, upload-time = "2024-08-12T09:41:07.954Z" },
+]
+
+[[package]]
 name = "ghp-import"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -165,6 +183,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d6/49/3732b0e8424ae35ad5c3166d9dd5bcdae43ce98775e0867a716ff5868064/librt-0.7.4-cp314-cp314t-win32.whl", hash = "sha256:8a461f6456981d8c8e971ff5a55f2e34f4e60871e665d2f5fde23ee74dea4eeb", size = 40276, upload-time = "2025-12-15T16:52:27.54Z" },
     { url = "https://files.pythonhosted.org/packages/35/d6/d8823e01bd069934525fddb343189c008b39828a429b473fb20d67d5cd36/librt-0.7.4-cp314-cp314t-win_amd64.whl", hash = "sha256:721a7b125a817d60bf4924e1eec2a7867bfcf64cfc333045de1df7a0629e4481", size = 46772, upload-time = "2025-12-15T16:52:28.653Z" },
     { url = "https://files.pythonhosted.org/packages/36/e9/a0aa60f5322814dd084a89614e9e31139702e342f8459ad8af1984a18168/librt-0.7.4-cp314-cp314t-win_arm64.whl", hash = "sha256:76b2ba71265c0102d11458879b4d53ccd0b32b0164d14deb8d2b598a018e502f", size = 39724, upload-time = "2025-12-15T16:52:29.836Z" },
+]
+
+[[package]]
+name = "mako"
+version = "1.3.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/00/62/791b31e69ae182791ec67f04850f2f062716bbd205483d63a215f3e062d3/mako-1.3.12.tar.gz", hash = "sha256:9f778e93289bd410bb35daadeb4fc66d95a746f0b75777b942088b7fd7af550a", size = 400219, upload-time = "2026-04-28T19:01:08.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/b1/a0ec7a5a9db730a08daef1fdfb8090435b82465abbf758a596f0ea88727e/mako-1.3.12-py3-none-any.whl", hash = "sha256:8f61569480282dbf557145ce441e4ba888be453c30989f879f0d652e39f53ea9", size = 78521, upload-time = "2026-04-28T19:01:10.393Z" },
 ]
 
 [[package]]
@@ -364,6 +394,18 @@ wheels = [
 ]
 
 [[package]]
+name = "openpyxl"
+version = "3.1.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "et-xmlfile" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/f9/88d94a75de065ea32619465d2f77b29a0469500e99012523b91cc4141cd1/openpyxl-3.1.5.tar.gz", hash = "sha256:cf0e3cf56142039133628b5acffe8ef0c12bc902d2aadd3e0fe5878dc08d1050", size = 186464, upload-time = "2024-06-28T14:03:44.161Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/da/977ded879c29cbd04de313843e76868e6e13408a94ed6b987245dc7c8506/openpyxl-3.1.5-py2.py3-none-any.whl", hash = "sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2", size = 250910, upload-time = "2024-06-28T14:03:41.161Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "25.0"
 source = { registry = "https://pypi.org/simple" }
@@ -386,6 +428,28 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ed/9d/36af210c7cef275d646b8dded8cc555078a271514e34f8f8d1c056462dc3/pandera-0.27.0.tar.gz", hash = "sha256:83c66d5896b97b3a91c810621038d2495f56c83864493819e7587d2059e641ad", size = 567135, upload-time = "2025-11-25T16:20:35.156Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d5/26/8e4a28ffbf3406c60d58eaa7f0529fb6197f5ae49f77b173dc84c057e1a2/pandera-0.27.0-py3-none-any.whl", hash = "sha256:e43b8062dfcde984300d798686815cc93feaae09645d3cddee3ab437f2d11ed5", size = 295880, upload-time = "2025-11-25T16:20:33.635Z" },
+]
+
+[[package]]
+name = "parse"
+version = "1.22.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/a2/dd269daedd5ac3a244ca7855b4878d8655393fd4554d5c24a56bc31e302a/parse-1.22.0.tar.gz", hash = "sha256:d4987d68ccf08b6ba3bf80b5004ff7de61c4337cba2d8350ae5c9925794979d9", size = 36767, upload-time = "2026-05-02T01:36:25.575Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/3a/0c2cf5922c6133b74c1cebe4b66f6949818e2cf8121aa59e3ebcd64ac6ac/parse-1.22.0-py2.py3-none-any.whl", hash = "sha256:eea8ed34e2614cea65d9c1d4af9cb68cce26aea13d44bdcaf83c1b40884fe945", size = 20839, upload-time = "2026-05-02T01:36:24.403Z" },
+]
+
+[[package]]
+name = "parse-type"
+version = "0.6.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "parse" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/ea/42ba6ce0abba04ab6e0b997dcb9b528a4661b62af1fe1b0d498120d5ea78/parse_type-0.6.6.tar.gz", hash = "sha256:513a3784104839770d690e04339a8b4d33439fcd5dd99f2e4580f9fc1097bfb2", size = 98012, upload-time = "2025-08-11T22:53:48.066Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/8d/eef3d8cdccc32abdd91b1286884c99b8c3a6d3b135affcc2a7a0f383bb32/parse_type-0.6.6-py2.py3-none-any.whl", hash = "sha256:3ca79bbe71e170dfccc8ec6c341edfd1c2a0fc1e5cfd18330f93af938de2348c", size = 27085, upload-time = "2025-08-11T22:53:46.396Z" },
 ]
 
 [[package]]
@@ -532,6 +596,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+]
+
+[[package]]
+name = "pytest-bdd"
+version = "8.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gherkin-official" },
+    { name = "mako" },
+    { name = "packaging" },
+    { name = "parse" },
+    { name = "parse-type" },
+    { name = "pytest" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2d/2f/14c2e55372a5718a93b56aea48cd6ccc15d2d245364e516cd7b19bbd07ad/pytest_bdd-8.1.0.tar.gz", hash = "sha256:ef0896c5cd58816dc49810e8ff1d632f4a12019fb3e49959b2d349ffc1c9bfb5", size = 56147, upload-time = "2024-12-05T21:45:58.83Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/7d/1461076b0cc9a9e6fa8b51b9dea2677182ba8bc248d99d95ca321f2c666f/pytest_bdd-8.1.0-py3-none-any.whl", hash = "sha256:2124051e71a05ad7db15296e39013593f72ebf96796e1b023a40e5453c47e5fb", size = 49149, upload-time = "2024-12-05T21:45:56.184Z" },
 ]
 
 [[package]]
@@ -691,10 +773,11 @@ wheels = [
 
 [[package]]
 name = "waccy"
-version = "0.0.2a0"
+version = "0.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },
+    { name = "openpyxl" },
     { name = "pandera" },
     { name = "polars" },
     { name = "pydantic" },
@@ -712,6 +795,7 @@ quickbooks = [
 dev = [
     { name = "mypy" },
     { name = "pytest" },
+    { name = "pytest-bdd" },
     { name = "pytest-cov" },
     { name = "ruff" },
 ]
@@ -722,11 +806,12 @@ docs = [
 [package.metadata]
 requires-dist = [
     { name = "numpy", specifier = ">=2.3.5" },
+    { name = "openpyxl", specifier = ">=3.1.5" },
     { name = "pandera", specifier = ">=0.27.0" },
     { name = "polars", specifier = ">=1.36.1" },
     { name = "pydantic", specifier = ">=2.12.5" },
-    { name = "waccy-edgar", marker = "extra == 'edgar'", specifier = ">=0.0.0" },
-    { name = "waccy-quickbooks", marker = "extra == 'quickbooks'", specifier = ">=0.0.0" },
+    { name = "waccy-edgar", marker = "extra == 'edgar'", specifier = ">=0.0.1" },
+    { name = "waccy-quickbooks", marker = "extra == 'quickbooks'", specifier = ">=0.0.1" },
 ]
 provides-extras = ["quickbooks", "edgar"]
 
@@ -734,6 +819,7 @@ provides-extras = ["quickbooks", "edgar"]
 dev = [
     { name = "mypy", specifier = ">=1.13.0" },
     { name = "pytest", specifier = ">=9.0.2" },
+    { name = "pytest-bdd", specifier = ">=8.1.0" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
     { name = "ruff", specifier = ">=0.8.0" },
 ]
@@ -741,14 +827,14 @@ docs = [{ name = "mkdocs", specifier = ">=1.6.1" }]
 
 [[package]]
 name = "waccy-edgar"
-version = "0.0.1a0"
+version = "0.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "waccy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6e/63/07e203beafed9309aa21916f03ea9fcce76fa0132a3074e93d37b1604f54/waccy_edgar-0.0.1a0.tar.gz", hash = "sha256:0eb3b7f794e928786e9c1e2e018b97127085f670566f0e04e373e5eaa6b8ce5a", size = 2489, upload-time = "2025-12-16T04:47:53.933Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/06/a0cd6e6a6f7243dd9974940ba937b6045e403882d993e726d6fc92cabcd0/waccy_edgar-0.0.2.tar.gz", hash = "sha256:00ff1ee136d5aff29646ec18d6bf2c2feb2e2e4cd768c10958fff23fafa41449", size = 2489, upload-time = "2025-12-16T04:52:44.227Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/57/f0/7c5c4eb494dfad24aaf95ec53137fd7e40f2b407b22a038da1474d7d8db8/waccy_edgar-0.0.1a0-py3-none-any.whl", hash = "sha256:e7440a46dcdf47e1b2d17add0730bc8ac83d4e915a48dd49aa2cd6490dc7924c", size = 2678, upload-time = "2025-12-16T04:47:52.668Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/09/8cd3edb2cbded3950a177b340ed0a1ee8388fbc598c9a1b524c99f8fadf2/waccy_edgar-0.0.2-py3-none-any.whl", hash = "sha256:3cb2817c2ee807e001e8cba8a0073b57f732244583872d665bb969dab81f32d5", size = 2662, upload-time = "2025-12-16T04:52:43.274Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Refactors docs into the mission, experience, requirements, and architecture structure.
- Implements the v0.1.0 layered financial dataset pipeline from source records through mapped/validated datasets, three-statement model building, and XLSX export.
- Adds QBO and EDGAR fixture-first extractors, deterministic ontology aliases, API-first mapping overrides, and validation checks.
- Adds GitHub CI, Codecov configuration, CodeRabbit configuration, issue/PR templates, and BDD outcome specs.

## Validation

- `uv run ruff check`
- `uv run mypy src/waccy`
- `uv run pytest tests/bdd -q -m 'bdd or outcome'`\n- `uv run pytest --cov=src/waccy --cov-report=term-missing --cov-report=xml --cov-fail-under=80`\n\n## Notes\n\n- CodeRabbit reviews require the CodeRabbit GitHub app to be installed on the repository.\n- Codecov upload is configured through the official `codecov/codecov-action@v5` action using OIDC.\n

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DecisionNerd/codesmith/waccy/pr/17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk: introduces new core data-contract models, mapping/validation logic, and XLSX export that will affect future financial correctness and outputs. CI gates and added tests reduce risk but statement math and alias-based mapping could still misclassify or mis-balance edge-case datasets.
> 
> **Overview**
> **Implements the v0.1.0 fixture-first modeling pipeline** from extractor output → normalized records → mapped/validated datasets → a canonical `ThreeStatementModel`.
> 
> Adds a minimal standard ontology with alias-based deterministic mapping (plus mapping overrides), mapped-dataset validation (unmapped/ambiguous accounts, period defects), three-statement construction with balance-sheet and cash-flow tie-out checks, and an `openpyxl`-based XLSX exporter that writes the three statement sheets.
> 
> **Raises quality/ops automation** by adding GitHub Actions CI (ruff/mypy/pytest + 90% coverage, Codecov upload) and BDD outcome specs, plus new Makefile targets, CodeRabbit/Codecov config, and updated docs/templates/README to reflect the current scaffold and v0.1.0 goals.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cca63c792fe5316224fc296b2811eedc21dbbe04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * v0.1.0 three-statement model builder, XLSX exporter, and fixture-driven QuickBooks/EDGAR extractors with end-to-end mapping pipeline.
* **Validation**
  * Dataset and mapped-dataset validation with diagnostics, quality scoring, and validation issue reporting.
* **Documentation**
  * Reworked mission, experience, requirements, testing guidance, README and extension docs for v0.1.0; added testing guidance.
* **Tests**
  * New BDD outcome specs and extensive unit tests covering pipeline, validation, and XLSX export.
* **Chores**
  * CI/workflow, Makefile, PR/issue templates, coverage tooling, and CodeRabbit configuration.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DecisionNerd/waccy/pull/17)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->