### PR TITLE
Implement QBO release-validity pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ WACCY is an early package, but the v0.1.0 vertical slice now implements a fixtur
 * XLSX export with the three required workbook sheets
 * pandas DataFrame export for follow-on modeling outside WACCY
 
-The QuickBooks helper pulls raw QBO company info, chart of accounts, and reports; deterministic live-report normalization into WACCY source records is still tracked separately. Live EDGAR fetching and richer filing parsing remain planned. The first milestone remains focused on hardening the QBO/EDGAR path into the [v0.1.0 release](https://github.com/DecisionNerd/waccy/milestone/1), tracked by [issue #15](https://github.com/DecisionNerd/waccy/issues/15).
+The QuickBooks helper pulls raw QBO company info, chart of accounts, and reports, then normalizes those reports into WACCY source records. Live EDGAR fetching and richer filing parsing remain planned. The first milestone remains focused on hardening the QBO/EDGAR path into the [v0.1.0 release](https://github.com/DecisionNerd/waccy/milestone/1), tracked by [issue #15](https://github.com/DecisionNerd/waccy/issues/15).
 
 ## Quick Start
 
@@ -75,7 +75,7 @@ Implemented v0.1.0 components include:
 
 Still planned:
 
-* deterministic QBO live-report normalization into WACCY source records
+* full live QuickBooks product workflow beyond report pulling and normalization
 * live EDGAR fetching and richer filing parsing
 * LLM-assisted classification and confidence scoring beyond placeholders
 * advanced model types such as DCF, LBO, M&A, and specialized industry models

--- a/README.md
+++ b/README.md
@@ -19,13 +19,15 @@ Unlike large enterprises with dedicated accounting teams, small businesses often
 WACCY is an early package, but the v0.1.0 vertical slice now implements a fixture-first financial modeling path:
 
 * QBO/QuickBooks-shaped fixture extraction through `QuickBooksExtractor`
+* a small typed QuickBooks OAuth/report puller in `waccy-quickbooks`
 * EDGAR/XBRL-shaped fixture extraction through `EdgarExtractor`
 * normalized, mapped, and validated financial datasets
 * deterministic source-to-WACCY account mapping with override support
 * three-statement model construction with reconciliation checks
 * XLSX export with the three required workbook sheets
+* pandas DataFrame export for follow-on modeling outside WACCY
 
-Live QuickBooks and EDGAR API clients are not implemented yet. The first milestone remains focused on hardening the fixture-first path into the [v0.1.0 release](https://github.com/DecisionNerd/waccy/milestone/1), tracked by [issue #15](https://github.com/DecisionNerd/waccy/issues/15).
+The QuickBooks helper pulls raw QBO company info, chart of accounts, and reports; deterministic live-report normalization into WACCY source records is still tracked separately. Live EDGAR fetching and richer filing parsing remain planned. The first milestone remains focused on hardening the QBO/EDGAR path into the [v0.1.0 release](https://github.com/DecisionNerd/waccy/milestone/1), tracked by [issue #15](https://github.com/DecisionNerd/waccy/issues/15).
 
 ## Quick Start
 
@@ -63,15 +65,17 @@ print(f"Available data sources: {available_sources}")
 Implemented v0.1.0 components include:
 
 * fixture-first QBO and EDGAR extraction
+* typed QBO OAuth token cache, raw report pulling, and deterministic report normalization
 * standard account ontology and deterministic aliases
 * mapping, validation, reconciliation, and quality diagnostics
 * three-statement model building
 * spreadsheet export
+* pandas DataFrame handoff for external modeling workflows
 * local and CI quality gates with BDD outcome specs
 
 Still planned:
 
-* live QuickBooks OAuth/API extraction
+* deterministic QBO live-report normalization into WACCY source records
 * live EDGAR fetching and richer filing parsing
 * LLM-assisted classification and confidence scoring beyond placeholders
 * advanced model types such as DCF, LBO, M&A, and specialized industry models
@@ -406,6 +410,7 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
   * [uv](https://github.com/astral-sh/uv) - Modern Python package manager
   * [ruff](https://github.com/astral-sh/ruff) - Fast Python linter and formatter
   * [Pydantic](https://github.com/pydantic/pydantic) - Data validation framework
+  * [pandas](https://github.com/pandas-dev/pandas) - DataFrame handoff for downstream modeling
   * [Polars](https://github.com/pola-rs/polars) - High-performance data manipulation
   * [Pandera](https://github.com/pandera-dev/pandera) - Statistical data validation
 

--- a/docs/1-EXPERIENCE.md
+++ b/docs/1-EXPERIENCE.md
@@ -71,7 +71,7 @@ Confidence scoring should help prioritize review. It should not imply false prec
 
 The following are important to the broader mission but should not block the first vertical slice:
 
-- Full live QuickBooks OAuth flow beyond a documented integration path
+- A full live QuickBooks product workflow beyond the typed OAuth/report-pull helper
 - Full EDGAR pattern-learning system
 - DCF, LBO, M&A, SaaS cohort, or other advanced model types
 - Google Sheets API export

--- a/docs/3-ARCHITECTURE.md
+++ b/docs/3-ARCHITECTURE.md
@@ -251,6 +251,7 @@ classifiers = [
 
 dependencies = [
     "numpy>=2.3.5",
+    "pandas>=3.0.2",
     "pandera>=0.27.0",
     "polars>=1.36.1",
     "pydantic>=2.12.5",

--- a/docs/3-ARCHITECTURE.md
+++ b/docs/3-ARCHITECTURE.md
@@ -73,6 +73,8 @@ QBO is the primary small-business accounting source. The integration should extr
 
 Architecturally, QBO data should not be trusted blindly. Source account names and account types are useful signals, but WACCY should still map them through the standard ontology and report confidence or ambiguity.
 
+The v0.1.0 QBO path keeps live API access and raw report normalization in `waccy-quickbooks`. Raw QBO `CompanyInfo`, `Account`, `ProfitAndLoss`, `BalanceSheet`, and `CashFlow` payloads are normalized into WACCY fixture-shaped source records before the core mapper, validator, model builder, XLSX exporter, or pandas handoff sees them.
+
 ### SEC EDGAR
 
 EDGAR serves two architectural roles:
@@ -695,7 +697,8 @@ uv publish
 
 Core platform maintains minimal dependencies:
 - **pydantic**: Data validation and models
-- **polars**: Efficient data manipulation (preferred over pandas for performance)
+- **pandas**: DataFrame handoff for downstream modeling outside WACCY
+- **polars**: Efficient internal data manipulation where columnar performance matters
 - **pandera**: Data validation schemas
 - **numpy**: Numerical computations
 

--- a/extensions/waccy-quickbooks/README.md
+++ b/extensions/waccy-quickbooks/README.md
@@ -4,7 +4,7 @@ WACCY extension for QuickBooks Online integration.
 
 ## Status
 
-This package currently provides fixture-first QuickBooks/QBO-shaped extraction and the entry point for `ExtractorRegistry` discovery. Live QuickBooks OAuth and API extraction are not implemented yet. The v0.1.0 work is tracked in:
+This package provides fixture-first QuickBooks/QBO-shaped extraction, the entry point for `ExtractorRegistry` discovery, and a small typed live-pull helper for OAuth-backed QBO reports. The live helper intentionally returns raw QBO JSON; WACCY's model-building contract still begins after source data is normalized into WACCY records. The v0.1.0 work is tracked in:
 
 - [#5 Implement QuickBooks/QBO extraction for three-statement source data](https://github.com/DecisionNerd/waccy/issues/5)
 - [v0.1.0 milestone](https://github.com/DecisionNerd/waccy/milestone/1)
@@ -21,7 +21,7 @@ Or install with the core platform:
 uv pip install "waccy[quickbooks]"
 ```
 
-## Current Usage
+## Fixture Usage
 
 ```python
 from waccy.extraction import ExtractorRegistry
@@ -31,27 +31,44 @@ extractor = registry.get_extractor("qbo")()
 print(extractor.name)
 ```
 
-The following live API path is planned but not runnable yet:
+## Live QBO Report Pull
+
+Use Intuit OAuth to create or refresh a token, then pull raw company info, chart of accounts, and reports. Store the token cache in a caller-owned path; do not commit it.
 
 ```python
-from waccy.extraction import ExtractorRegistry
+from datetime import date
 
-registry = ExtractorRegistry()
-extractor = registry.get_extractor("qbo")()
+from waccy_quickbooks import (
+    FileTokenCache,
+    QuickBooksApiClient,
+    QuickBooksOAuthConfig,
+)
 
-# Authenticate
-extractor.authenticate({
-    "client_id": "your_client_id",
-    "client_secret": "your_client_secret",
-    "access_token": "your_access_token"
-})
+config = QuickBooksOAuthConfig(
+    client_id="...",
+    client_secret="...",
+    redirect_uri="http://localhost:8765/callback",
+    environment="sandbox",
+)
+cache = FileTokenCache("~/.waccy/qbo-token.json")
+client = QuickBooksApiClient.from_token_cache(cache, config)
 
-# Extract data
-data = extractor.extract({
-    "company_id": "your_company_id",
-    "date_range": ("2023-01-01", "2024-12-31")
-})
+pull = client.pull_financial_reports(
+    start_date=date(2024, 1, 1),
+    end_date=date(2024, 12, 31),
+)
 ```
+
+The returned `QuickBooksReportPull` carries raw `CompanyInfo`, `Account`, `ProfitAndLoss`, `BalanceSheet`, and `CashFlow` payloads. Convert that raw pull into WACCY source records with the report normalizer:
+
+```python
+from waccy_quickbooks import QuickBooksExtractor, QuickBooksReportNormalizer
+
+fixture = QuickBooksReportNormalizer().to_fixture(pull)
+extracted = QuickBooksExtractor().extract({"fixture": fixture})
+```
+
+The normalizer preserves QBO report provenance in record metadata, detects `NoReportData` reports, and emits source-completeness diagnostics for missing required statements. Keep live pull artifacts and token caches out of git. Use sanitized raw fixtures for repeatable CI/local smoke tests.
 
 ## Development
 

--- a/extensions/waccy-quickbooks/pyproject.toml
+++ b/extensions/waccy-quickbooks/pyproject.toml
@@ -17,9 +17,8 @@ classifiers = [
     "Topic :: Office/Business :: Financial",
 ]
 dependencies = [
+    "intuit-oauth>=1.2.6",
     "waccy>=0.0.2",
-    # Add QuickBooks API client dependency when implemented
-    # "quickbooks-python>=1.0.0",
 ]
 
 [project.optional-dependencies]
@@ -76,3 +75,7 @@ strict_equality = true
 [[tool.mypy.overrides]]
 module = "tests.*"
 disallow_untyped_defs = false
+
+[[tool.mypy.overrides]]
+module = ["intuitlib", "intuitlib.*", "waccy", "waccy.*"]
+ignore_missing_imports = true

--- a/extensions/waccy-quickbooks/src/waccy_quickbooks/__init__.py
+++ b/extensions/waccy-quickbooks/src/waccy_quickbooks/__init__.py
@@ -1,4 +1,30 @@
 """WACCY extension for QuickBooks Online integration."""
 
+from waccy_quickbooks.auth import QuickBooksOAuthClient
+from waccy_quickbooks.client import QuickBooksApiClient, QuickBooksApiError
+from waccy_quickbooks.extractor import QuickBooksExtractor
+from waccy_quickbooks.models import (
+    QuickBooksEnvironment,
+    QuickBooksOAuthConfig,
+    QuickBooksReportPull,
+    QuickBooksReportRequest,
+    QuickBooksToken,
+)
+from waccy_quickbooks.normalizer import QuickBooksReportNormalizer
+from waccy_quickbooks.token_cache import FileTokenCache
+
 __version__ = "0.1.0"
 
+__all__ = [
+    "FileTokenCache",
+    "QuickBooksApiClient",
+    "QuickBooksApiError",
+    "QuickBooksEnvironment",
+    "QuickBooksExtractor",
+    "QuickBooksOAuthClient",
+    "QuickBooksOAuthConfig",
+    "QuickBooksReportNormalizer",
+    "QuickBooksReportPull",
+    "QuickBooksReportRequest",
+    "QuickBooksToken",
+]

--- a/extensions/waccy-quickbooks/src/waccy_quickbooks/auth.py
+++ b/extensions/waccy-quickbooks/src/waccy_quickbooks/auth.py
@@ -1,0 +1,71 @@
+"""QuickBooks OAuth helpers built on Intuit's official OAuth client."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from waccy_quickbooks.models import QuickBooksOAuthConfig, QuickBooksToken
+
+ACCOUNTING_SCOPE = "com.intuit.quickbooks.accounting"
+
+
+class QuickBooksOAuthClient:
+    """Thin wrapper around ``intuit-oauth`` for WACCY's token model."""
+
+    def __init__(self, config: QuickBooksOAuthConfig) -> None:
+        self.config = config
+
+    def authorization_url(self, state_token: str | None = None, scopes: list[Any] | None = None) -> str:
+        """Build an Intuit authorization URL."""
+        auth_client = self._auth_client(state_token=state_token)
+        return str(auth_client.get_authorization_url(scopes or [self._accounting_scope()]))
+
+    def exchange_code(self, auth_code: str, realm_id: str) -> QuickBooksToken:
+        """Exchange an OAuth authorization code for bearer tokens."""
+        auth_client = self._auth_client(realm_id=realm_id)
+        auth_client.get_bearer_token(auth_code, realm_id=realm_id)
+        return self._token_from_auth_client(auth_client, realm_id)
+
+    def refresh(self, token: QuickBooksToken) -> QuickBooksToken:
+        """Refresh a cached token and return the updated token state."""
+        auth_client = self._auth_client(
+            access_token=token.access_token,
+            refresh_token=token.refresh_token,
+            realm_id=token.realm_id,
+        )
+        auth_client.refresh(refresh_token=token.refresh_token)
+        return self._token_from_auth_client(auth_client, token.realm_id)
+
+    def _auth_client(self, **kwargs: Any) -> Any:
+        from intuitlib.client import AuthClient  # noqa: PLC0415
+
+        return AuthClient(
+            client_id=self.config.client_id,
+            client_secret=self.config.client_secret,
+            redirect_uri=self.config.redirect_uri,
+            environment=self.config.environment.value,
+            **kwargs,
+        )
+
+    @staticmethod
+    def _accounting_scope() -> Any:
+        from intuitlib.enums import Scopes  # noqa: PLC0415
+
+        return Scopes.ACCOUNTING
+
+    @staticmethod
+    def _token_from_auth_client(auth_client: Any, realm_id: str) -> QuickBooksToken:
+        now = datetime.now(UTC)
+        expires_in = int(getattr(auth_client, "expires_in", 3600) or 3600)
+        refresh_expires_in = getattr(auth_client, "x_refresh_token_expires_in", None)
+        return QuickBooksToken(
+            access_token=str(auth_client.access_token),
+            refresh_token=str(auth_client.refresh_token),
+            realm_id=realm_id,
+            token_type=str(getattr(auth_client, "token_type", "bearer") or "bearer"),
+            expires_at=now + timedelta(seconds=expires_in),
+            refresh_token_expires_at=(
+                now + timedelta(seconds=int(refresh_expires_in)) if refresh_expires_in else None
+            ),
+        )

--- a/extensions/waccy-quickbooks/src/waccy_quickbooks/client.py
+++ b/extensions/waccy-quickbooks/src/waccy_quickbooks/client.py
@@ -1,0 +1,193 @@
+"""Tiny typed QuickBooks Online report puller."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable, Iterable
+from typing import TYPE_CHECKING, Any
+from urllib.error import HTTPError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+from waccy_quickbooks.auth import QuickBooksOAuthClient
+from waccy_quickbooks.models import (
+    QuickBooksEnvironment,
+    QuickBooksOAuthConfig,
+    QuickBooksReportPull,
+    QuickBooksReportRequest,
+    QuickBooksToken,
+)
+
+if TYPE_CHECKING:
+    from datetime import date
+
+    from waccy_quickbooks.token_cache import FileTokenCache
+
+DEFAULT_REPORTS = ("ProfitAndLoss", "BalanceSheet", "CashFlow")
+Transport = Callable[[Request, float], bytes]
+
+
+class QuickBooksApiError(RuntimeError):
+    """Raised when QBO returns an HTTP error or malformed JSON."""
+
+
+class QuickBooksApiClient:
+    """Pull raw QBO JSON for the reports WACCY needs."""
+
+    def __init__(
+        self,
+        token: QuickBooksToken,
+        environment: QuickBooksEnvironment = QuickBooksEnvironment.SANDBOX,
+        *,
+        transport: Transport | None = None,
+        timeout: float = 30.0,
+    ) -> None:
+        self.token = token
+        self.environment = environment
+        self.transport = transport or self._default_transport
+        self.timeout = timeout
+
+    @classmethod
+    def from_token_cache(
+        cls,
+        cache: FileTokenCache,
+        oauth_config: QuickBooksOAuthConfig,
+        *,
+        transport: Transport | None = None,
+        timeout: float = 30.0,
+    ) -> QuickBooksApiClient:
+        """Create a client from cached token state, refreshing when needed."""
+        token = cache.load()
+        if token is None:
+            raise ValueError("QuickBooks token cache is empty; complete OAuth before pulling reports.")
+        if token.is_access_token_expired():
+            token = QuickBooksOAuthClient(oauth_config).refresh(token)
+            cache.save(token)
+        return cls(
+            token,
+            oauth_config.environment,
+            transport=transport,
+            timeout=timeout,
+        )
+
+    def get_company_info(self) -> dict[str, Any]:
+        """Return the QBO CompanyInfo payload."""
+        path = f"/v3/company/{self.token.realm_id}/companyinfo/{self.token.realm_id}"
+        return self._request_json(path)
+
+    def get_accounts(self, *, page_size: int = 1000) -> list[dict[str, Any]]:
+        """Return all chart-of-account rows visible to the token."""
+        accounts: list[dict[str, Any]] = []
+        start_position = 1
+        while True:
+            query = (
+                "select * from Account "
+                f"startposition {start_position} maxresults {page_size}"
+            )
+            payload = self._request_json(
+                f"/v3/company/{self.token.realm_id}/query",
+                {"query": query},
+            )
+            batch = payload.get("QueryResponse", {}).get("Account", [])
+            if not isinstance(batch, list):
+                raise QuickBooksApiError("QBO Account query returned an unexpected payload shape.")
+            accounts.extend(batch)
+            if len(batch) < page_size:
+                return accounts
+            start_position += page_size
+
+    def get_report(self, request: QuickBooksReportRequest) -> dict[str, Any]:
+        """Return a raw QBO report payload."""
+        params = {
+            "start_date": request.start_date.isoformat(),
+            "end_date": request.end_date.isoformat(),
+            "accounting_method": request.accounting_method,
+        }
+        if request.summarize_column_by:
+            params["summarize_column_by"] = request.summarize_column_by
+        return self._request_json(
+            f"/v3/company/{self.token.realm_id}/reports/{request.report_name}",
+            params,
+        )
+
+    def pull_financial_reports(
+        self,
+        *,
+        start_date: date,
+        end_date: date,
+        report_names: Iterable[str] = DEFAULT_REPORTS,
+        accounting_method: str = "Accrual",
+        summarize_column_by: str | None = None,
+    ) -> QuickBooksReportPull:
+        """Pull company info, chart of accounts, and the requested report set."""
+        company_info = self.get_company_info()
+        accounts = self.get_accounts()
+        reports = {
+            report_name: self.get_report(
+                QuickBooksReportRequest(
+                    report_name=report_name,
+                    start_date=start_date,
+                    end_date=end_date,
+                    accounting_method=accounting_method,
+                    summarize_column_by=summarize_column_by,
+                )
+            )
+            for report_name in report_names
+        }
+        return QuickBooksReportPull(
+            realm_id=self.token.realm_id,
+            entity_name=_company_name(company_info),
+            environment=self.environment,
+            start_date=start_date,
+            end_date=end_date,
+            company_info=company_info,
+            accounts=accounts,
+            reports=reports,
+            metadata={"accounting_method": accounting_method},
+        )
+
+    def _request_json(self, path: str, params: dict[str, str] | None = None) -> dict[str, Any]:
+        query = f"?{urlencode(params)}" if params else ""
+        request = Request(
+            f"{self._base_url}{path}{query}",
+            headers={
+                "Accept": "application/json",
+                "Authorization": f"Bearer {self.token.access_token}",
+            },
+            method="GET",
+        )
+        try:
+            raw_response = self.transport(request, self.timeout)
+        except HTTPError as exc:
+            detail = exc.read().decode("utf-8", errors="replace")
+            raise QuickBooksApiError(f"QBO request failed with HTTP {exc.code}: {detail}") from exc
+        try:
+            payload = json.loads(raw_response.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise QuickBooksApiError("QBO returned a non-JSON response.") from exc
+        if not isinstance(payload, dict):
+            raise QuickBooksApiError("QBO returned an unexpected non-object JSON response.")
+        return payload
+
+    @property
+    def _base_url(self) -> str:
+        if self.environment == QuickBooksEnvironment.PRODUCTION:
+            return "https://quickbooks.api.intuit.com"
+        return "https://sandbox-quickbooks.api.intuit.com"
+
+    @staticmethod
+    def _default_transport(request: Request, timeout: float) -> bytes:
+        with urlopen(request, timeout=timeout) as response:
+            data = response.read()
+        if not isinstance(data, bytes):
+            raise QuickBooksApiError("QBO returned a non-bytes HTTP response.")
+        return data
+
+
+def _company_name(company_info: dict[str, Any]) -> str:
+    info = company_info.get("CompanyInfo", {})
+    if isinstance(info, dict):
+        name = info.get("CompanyName") or info.get("LegalName")
+        if name:
+            return str(name)
+    return "QuickBooks Entity"

--- a/extensions/waccy-quickbooks/src/waccy_quickbooks/client.py
+++ b/extensions/waccy-quickbooks/src/waccy_quickbooks/client.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from collections.abc import Callable, Iterable
 from typing import TYPE_CHECKING, Any
-from urllib.error import HTTPError
+from urllib.error import HTTPError, URLError
 from urllib.parse import urlencode
 from urllib.request import Request, urlopen
 
@@ -77,6 +77,8 @@ class QuickBooksApiClient:
 
     def get_accounts(self, *, page_size: int = 1000) -> list[dict[str, Any]]:
         """Return all chart-of-account rows visible to the token."""
+        if page_size <= 0:
+            raise ValueError("QBO account query page_size must be a positive integer.")
         accounts: list[dict[str, Any]] = []
         start_position = 1
         while True:
@@ -161,6 +163,8 @@ class QuickBooksApiClient:
         except HTTPError as exc:
             detail = exc.read().decode("utf-8", errors="replace")
             raise QuickBooksApiError(f"QBO request failed with HTTP {exc.code}: {detail}") from exc
+        except URLError as exc:
+            raise QuickBooksApiError(f"QBO request failed: {exc.reason}") from exc
         try:
             payload = json.loads(raw_response.decode("utf-8"))
         except (UnicodeDecodeError, json.JSONDecodeError) as exc:

--- a/extensions/waccy-quickbooks/src/waccy_quickbooks/models.py
+++ b/extensions/waccy-quickbooks/src/waccy_quickbooks/models.py
@@ -1,0 +1,73 @@
+"""Typed models for QuickBooks Online OAuth and report pulls."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime, timedelta
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class QuickBooksEnvironment(str, Enum):
+    """Supported Intuit API environments."""
+
+    SANDBOX = "sandbox"
+    PRODUCTION = "production"
+
+
+class QuickBooksOAuthConfig(BaseModel):
+    """OAuth application configuration for Intuit."""
+
+    client_id: str
+    client_secret: str
+    redirect_uri: str
+    environment: QuickBooksEnvironment = QuickBooksEnvironment.SANDBOX
+
+
+class QuickBooksToken(BaseModel):
+    """Stored QuickBooks OAuth token state."""
+
+    access_token: str
+    refresh_token: str
+    realm_id: str
+    token_type: str = "bearer"
+    expires_at: datetime | None = None
+    refresh_token_expires_at: datetime | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    def is_access_token_expired(
+        self, now: datetime | None = None, skew: timedelta = timedelta(minutes=5)
+    ) -> bool:
+        """Return whether the access token should be refreshed before use."""
+        if self.expires_at is None:
+            return False
+        current_time = now or datetime.now(UTC)
+        expires_at = self.expires_at
+        if expires_at.tzinfo is None:
+            expires_at = expires_at.replace(tzinfo=UTC)
+        return expires_at <= current_time + skew
+
+
+class QuickBooksReportRequest(BaseModel):
+    """Report request parameters for a QBO report endpoint."""
+
+    report_name: str
+    start_date: date
+    end_date: date
+    accounting_method: str = "Accrual"
+    summarize_column_by: str | None = None
+
+
+class QuickBooksReportPull(BaseModel):
+    """Raw QBO payloads needed before WACCY fixture normalization."""
+
+    realm_id: str
+    entity_name: str
+    environment: QuickBooksEnvironment
+    start_date: date
+    end_date: date
+    company_info: dict[str, Any]
+    accounts: list[dict[str, Any]]
+    reports: dict[str, dict[str, Any]]
+    metadata: dict[str, Any] = Field(default_factory=dict)

--- a/extensions/waccy-quickbooks/src/waccy_quickbooks/normalizer.py
+++ b/extensions/waccy-quickbooks/src/waccy_quickbooks/normalizer.py
@@ -30,6 +30,7 @@ class QuickBooksReportNormalizer:
         records: list[dict[str, Any]] = []
         periods: dict[str, dict[str, str]] = {}
         source_issues: list[dict[str, Any]] = []
+        issue_keys: set[tuple[str, str, str]] = set()
         report_record_counts: dict[str, int] = {}
 
         for period_label, reports in reports_by_period.items():
@@ -58,13 +59,15 @@ class QuickBooksReportNormalizer:
                 period = self._period_from_report(period_label, report)
                 periods.setdefault(period["label"], period)
                 if self._has_no_report_data(report):
-                    source_issues.append(
+                    self._append_issue(
+                        source_issues,
+                        issue_keys,
                         self._issue(
                             "qbo_report_no_data",
                             f"QBO report {report_name!r} has NoReportData=true for {period['label']}.",
                             report_name,
                             period["label"],
-                        )
+                        ),
                     )
 
                 before_count = len(records)
@@ -82,7 +85,9 @@ class QuickBooksReportNormalizer:
             for required_report in REQUIRED_REPORTS:
                 count = report_record_counts.get(f"{period_label}:{required_report}", 0)
                 if count == 0:
-                    source_issues.append(
+                    self._append_issue(
+                        source_issues,
+                        issue_keys,
                         self._issue(
                             "missing_required_source_statement",
                             (
@@ -91,7 +96,7 @@ class QuickBooksReportNormalizer:
                             ),
                             required_report,
                             period_label,
-                        )
+                        ),
                     )
 
         return {
@@ -350,8 +355,12 @@ class QuickBooksReportNormalizer:
     def _decimal(value: Any) -> Decimal | None:
         if value in {None, ""}:
             return None
+        normalized = str(value).strip().replace(",", "")
+        is_parenthesized_negative = normalized.startswith("(") and normalized.endswith(")")
+        if is_parenthesized_negative:
+            normalized = f"-{normalized[1:-1]}"
         try:
-            return Decimal(str(value).replace(",", ""))
+            return Decimal(normalized)
         except InvalidOperation:
             return None
 
@@ -376,3 +385,19 @@ class QuickBooksReportNormalizer:
             "report_name": report_name,
             "period_label": period_label,
         }
+
+    @staticmethod
+    def _append_issue(
+        issues: list[dict[str, Any]],
+        issue_keys: set[tuple[str, str, str]],
+        issue: dict[str, Any],
+    ) -> None:
+        key = (
+            str(issue.get("code", "")),
+            str(issue.get("report_name", "")),
+            str(issue.get("period_label", "")),
+        )
+        if key in issue_keys:
+            return
+        issue_keys.add(key)
+        issues.append(issue)

--- a/extensions/waccy-quickbooks/src/waccy_quickbooks/normalizer.py
+++ b/extensions/waccy-quickbooks/src/waccy_quickbooks/normalizer.py
@@ -1,0 +1,378 @@
+"""Normalize raw QuickBooks Online reports into WACCY fixture data."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal, InvalidOperation
+from typing import Any
+
+from waccy_quickbooks.models import QuickBooksReportPull
+
+REPORT_STATEMENTS = {
+    "ProfitAndLoss": "income_statement",
+    "BalanceSheet": "balance_sheet",
+    "CashFlow": "cash_flow_statement",
+}
+REQUIRED_REPORTS = tuple(REPORT_STATEMENTS)
+
+
+class QuickBooksReportNormalizer:
+    """Convert raw QBO report payloads into ``QuickBooksExtractor`` fixtures."""
+
+    def to_fixture(self, payload: QuickBooksReportPull | dict[str, Any]) -> dict[str, Any]:
+        """Return a WACCY-compatible fixture from raw QBO report data."""
+        data = payload.model_dump(mode="json") if isinstance(payload, QuickBooksReportPull) else payload
+        if not isinstance(data, dict):
+            raise ValueError("QBO normalization requires a dictionary or QuickBooksReportPull payload.")
+
+        reports_by_period = self._reports_by_period(data)
+        accounts_by_id = self._accounts_by_id(data.get("accounts", []))
+        records: list[dict[str, Any]] = []
+        periods: dict[str, dict[str, str]] = {}
+        source_issues: list[dict[str, Any]] = []
+        report_record_counts: dict[str, int] = {}
+
+        for period_label, reports in reports_by_period.items():
+            if not isinstance(reports, dict):
+                raise ValueError(f"QBO reports for period {period_label!r} must be a dictionary.")
+            present_reports = {self._report_name(report_name, report) for report_name, report in reports.items()}
+            source_issues.extend(
+                self._issue(
+                    "missing_required_source_statement",
+                    f"Missing required QBO report {required_report!r} for {period_label}.",
+                    required_report,
+                    period_label,
+                )
+                for required_report in REQUIRED_REPORTS
+                if required_report not in present_reports
+            )
+
+            for report_key, report in reports.items():
+                if not isinstance(report, dict):
+                    raise ValueError(f"QBO report {report_key!r} must be a dictionary.")
+                report_name = self._report_name(str(report_key), report)
+                statement = REPORT_STATEMENTS.get(report_name)
+                if statement is None:
+                    continue
+
+                period = self._period_from_report(period_label, report)
+                periods.setdefault(period["label"], period)
+                if self._has_no_report_data(report):
+                    source_issues.append(
+                        self._issue(
+                            "qbo_report_no_data",
+                            f"QBO report {report_name!r} has NoReportData=true for {period['label']}.",
+                            report_name,
+                            period["label"],
+                        )
+                    )
+
+                before_count = len(records)
+                self._collect_records(
+                    report=report,
+                    report_name=report_name,
+                    statement=statement,
+                    period_label=period["label"],
+                    accounts_by_id=accounts_by_id,
+                    records=records,
+                )
+                report_record_counts[f"{period['label']}:{report_name}"] = len(records) - before_count
+
+        for period_label in sorted(periods):
+            for required_report in REQUIRED_REPORTS:
+                count = report_record_counts.get(f"{period_label}:{required_report}", 0)
+                if count == 0:
+                    source_issues.append(
+                        self._issue(
+                            "missing_required_source_statement",
+                            (
+                                f"Required QBO report {required_report!r} produced no source records "
+                                f"for {period_label}."
+                            ),
+                            required_report,
+                            period_label,
+                        )
+                    )
+
+        return {
+            "entity_name": self._entity_name(data),
+            "periods": [periods[label] for label in sorted(periods)],
+            "accounts": list(accounts_by_id.values()),
+            "records": records,
+            "metadata": {
+                "source": "qbo",
+                "mode": "raw_report_normalized",
+                "qbo_source_issues": source_issues,
+            },
+        }
+
+    def _reports_by_period(self, data: dict[str, Any]) -> dict[str, dict[str, Any]]:
+        reports = data.get("reports")
+        if not isinstance(reports, dict):
+            raise ValueError("QBO normalization requires a 'reports' dictionary.")
+        if not reports:
+            raise ValueError("QBO normalization requires at least one report payload.")
+
+        if all(isinstance(report, dict) and "Header" in report for report in reports.values()):
+            label = self._period_from_report(
+                str(data.get("end_date", "report_period")),
+                next(iter(reports.values())),
+            )["label"]
+            return {label: reports}
+        return reports
+
+    def _accounts_by_id(self, raw_accounts: Any) -> dict[str, dict[str, Any]]:
+        if not isinstance(raw_accounts, list):
+            raise ValueError("QBO normalization requires 'accounts' to be a list.")
+        accounts: dict[str, dict[str, Any]] = {}
+        for account in raw_accounts:
+            if not isinstance(account, dict):
+                raise ValueError("QBO accounts must be dictionaries.")
+            account_id = account.get("Id") or account.get("id")
+            if account_id is not None:
+                accounts[str(account_id)] = account
+        return accounts
+
+    def _collect_records(
+        self,
+        *,
+        report: dict[str, Any],
+        report_name: str,
+        statement: str,
+        period_label: str,
+        accounts_by_id: dict[str, dict[str, Any]],
+        records: list[dict[str, Any]],
+    ) -> None:
+        rows = report.get("Rows", {}).get("Row", [])
+        if not isinstance(rows, list):
+            raise ValueError(f"QBO report {report_name!r} Rows.Row must be a list.")
+        self._walk_rows(
+            rows,
+            path=[],
+            report_name=report_name,
+            statement=statement,
+            period_label=period_label,
+            unit=str(report.get("Header", {}).get("Currency", "USD")),
+            accounts_by_id=accounts_by_id,
+            records=records,
+        )
+
+    def _walk_rows(
+        self,
+        rows: list[Any],
+        *,
+        path: list[str],
+        report_name: str,
+        statement: str,
+        period_label: str,
+        unit: str,
+        accounts_by_id: dict[str, dict[str, Any]],
+        records: list[dict[str, Any]],
+    ) -> None:
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            label = self._row_label(row)
+            next_path = [*path, label] if label else path
+            child_rows = row.get("Rows", {}).get("Row", [])
+            if isinstance(child_rows, list):
+                self._walk_rows(
+                    child_rows,
+                    path=next_path,
+                    report_name=report_name,
+                    statement=statement,
+                    period_label=period_label,
+                    unit=unit,
+                    accounts_by_id=accounts_by_id,
+                    records=records,
+                )
+            if row.get("type") == "Data":
+                record = self._record_from_row(
+                    row,
+                    path=next_path,
+                    report_name=report_name,
+                    statement=statement,
+                    period_label=period_label,
+                    unit=unit,
+                    accounts_by_id=accounts_by_id,
+                )
+                if record is not None:
+                    records.append(record)
+            elif report_name == "CashFlow":
+                summary_record = self._cash_flow_summary_record(
+                    row,
+                    path=next_path,
+                    report_name=report_name,
+                    statement=statement,
+                    period_label=period_label,
+                    unit=unit,
+                )
+                if summary_record is not None:
+                    records.append(summary_record)
+
+    def _record_from_row(
+        self,
+        row: dict[str, Any],
+        *,
+        path: list[str],
+        report_name: str,
+        statement: str,
+        period_label: str,
+        unit: str,
+        accounts_by_id: dict[str, dict[str, Any]],
+    ) -> dict[str, Any] | None:
+        columns = row.get("ColData", [])
+        if not isinstance(columns, list) or len(columns) < 2:
+            return None
+        account_column = columns[0]
+        amount_column = columns[-1]
+        if not isinstance(account_column, dict) or not isinstance(amount_column, dict):
+            return None
+        account_name = str(account_column.get("value", "")).strip()
+        if not account_name:
+            return None
+        amount = self._decimal(amount_column.get("value"))
+        if amount is None:
+            return None
+        account_id = str(account_column.get("id") or account_name)
+        account = accounts_by_id.get(account_id, {})
+        account_type = account.get("AccountType") or account.get("Classification")
+        return {
+            "source_account_id": account_id,
+            "source_account_name": account_name,
+            "name": account_name,
+            "period": period_label,
+            "amount": str(amount),
+            "statement": statement,
+            "source_account_type": str(account_type) if account_type else None,
+            "unit": unit,
+            "metadata": {
+                "report_name": report_name,
+                "row_path": path,
+                "qbo_account": account,
+                "qbo_row_type": row.get("type"),
+            },
+        }
+
+    def _cash_flow_summary_record(
+        self,
+        row: dict[str, Any],
+        *,
+        path: list[str],
+        report_name: str,
+        statement: str,
+        period_label: str,
+        unit: str,
+    ) -> dict[str, Any] | None:
+        summary = row.get("Summary", {}).get("ColData", [])
+        if not isinstance(summary, list) or len(summary) < 2:
+            return None
+        label_column = summary[0]
+        amount_column = summary[-1]
+        if not isinstance(label_column, dict) or not isinstance(amount_column, dict):
+            return None
+        label = str(label_column.get("value", "")).strip()
+        if label != "Net Change In Cash":
+            return None
+        amount = self._decimal(amount_column.get("value"))
+        if amount is None:
+            return None
+        return {
+            "source_account_id": label,
+            "source_account_name": label,
+            "name": label,
+            "period": period_label,
+            "amount": str(amount),
+            "statement": statement,
+            "unit": unit,
+            "metadata": {
+                "report_name": report_name,
+                "row_path": path,
+                "qbo_row_type": row.get("type"),
+                "is_summary_check": True,
+            },
+        }
+
+    def _period_from_report(self, fallback_label: str, report: dict[str, Any]) -> dict[str, str]:
+        header = report.get("Header", {})
+        start = str(header.get("StartPeriod") or "")
+        end = str(header.get("EndPeriod") or "")
+        if not end:
+            raise ValueError("QBO report Header.EndPeriod is required.")
+        start_date = date.fromisoformat(start or f"{end[:4]}-01-01")
+        end_date = date.fromisoformat(end)
+        label = end_date.strftime("%Y") if fallback_label == "report_period" else str(fallback_label)
+        if label.endswith("-12-31") or label.endswith("-06-30"):
+            label = end_date.strftime("%Y")
+        return {
+            "label": label,
+            "start_date": start_date.isoformat(),
+            "end_date": end_date.isoformat(),
+            "period_type": "year",
+        }
+
+    @staticmethod
+    def _report_name(report_key: str, report: Any) -> str:
+        if isinstance(report, dict):
+            header_name = report.get("Header", {}).get("ReportName")
+            if header_name:
+                return str(header_name)
+        return report_key
+
+    @staticmethod
+    def _has_no_report_data(report: dict[str, Any]) -> bool:
+        options = report.get("Header", {}).get("Option", [])
+        if not isinstance(options, list):
+            return False
+        for option in options:
+            if (
+                isinstance(option, dict)
+                and option.get("Name") == "NoReportData"
+                and str(option.get("Value", "")).lower() == "true"
+            ):
+                return True
+        return False
+
+    @staticmethod
+    def _row_label(row: dict[str, Any]) -> str:
+        header = row.get("Header", {}).get("ColData", [])
+        if isinstance(header, list) and header and isinstance(header[0], dict):
+            return str(header[0].get("value", "")).strip()
+        summary = row.get("Summary", {}).get("ColData", [])
+        if isinstance(summary, list) and summary and isinstance(summary[0], dict):
+            return str(summary[0].get("value", "")).strip()
+        columns = row.get("ColData", [])
+        if isinstance(columns, list) and columns and isinstance(columns[0], dict):
+            return str(columns[0].get("value", "")).strip()
+        return ""
+
+    @staticmethod
+    def _decimal(value: Any) -> Decimal | None:
+        if value in {None, ""}:
+            return None
+        try:
+            return Decimal(str(value).replace(",", ""))
+        except InvalidOperation:
+            return None
+
+    @staticmethod
+    def _entity_name(data: dict[str, Any]) -> str:
+        if data.get("entity_name"):
+            return str(data["entity_name"])
+        company_info = data.get("company_info", {}).get("CompanyInfo", {})
+        if isinstance(company_info, dict):
+            name = company_info.get("CompanyName") or company_info.get("LegalName")
+            if name:
+                return str(name)
+        return "QuickBooks Entity"
+
+    @staticmethod
+    def _issue(code: str, message: str, report_name: str, period_label: str) -> dict[str, str]:
+        return {
+            "code": code,
+            "message": message,
+            "severity": "error",
+            "source": "qbo",
+            "report_name": report_name,
+            "period_label": period_label,
+        }

--- a/extensions/waccy-quickbooks/src/waccy_quickbooks/token_cache.py
+++ b/extensions/waccy-quickbooks/src/waccy_quickbooks/token_cache.py
@@ -1,0 +1,31 @@
+"""Small file-backed token cache for QuickBooks OAuth state."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from waccy_quickbooks.models import QuickBooksToken
+
+
+class FileTokenCache:
+    """Persist QuickBooks OAuth tokens in a caller-owned JSON file."""
+
+    def __init__(self, path: str | Path) -> None:
+        self.path = Path(path).expanduser()
+
+    def load(self) -> QuickBooksToken | None:
+        """Load a token if the cache exists."""
+        if not self.path.exists():
+            return None
+        return QuickBooksToken.model_validate_json(self.path.read_text(encoding="utf-8"))
+
+    def save(self, token: QuickBooksToken) -> None:
+        """Write the token cache with owner-only permissions where supported."""
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.path.write_text(token.model_dump_json(indent=2), encoding="utf-8")
+        self.path.chmod(0o600)
+
+    def clear(self) -> None:
+        """Remove cached token state if present."""
+        if self.path.exists():
+            self.path.unlink()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
 dependencies = [
     "numpy>=2.3.5",
     "openpyxl>=3.1.5",
+    "pandas>=3.0.2",
     "pandera>=0.27.0",
     "polars>=1.36.1",
     "pydantic>=2.12.5",

--- a/src/waccy/core/ontology.py
+++ b/src/waccy/core/ontology.py
@@ -57,27 +57,27 @@ class StandardChartOfAccounts:
     def _initialize_standard_accounts(self) -> None:
         """Initialize the minimum chart of accounts for v0.1.0."""
         account_specs = [
-            ("revenue", "Revenue", AccountType.REVENUE, "income_statement", "credit", None, 100, ["sales", "sales revenue", "total revenue", "us-gaap:revenues", "revenues"]),
+            ("revenue", "Revenue", AccountType.REVENUE, "income_statement", "credit", None, 100, ["sales", "sales revenue", "total revenue", "income", "us-gaap:revenues", "revenues"]),
             ("cogs", "Cost of Goods Sold", AccountType.EXPENSE, "income_statement", "debit", None, 200, ["cost of goods sold", "cost of revenue", "cost of sales", "us-gaap:costofrevenue"]),
             ("operating_expenses", "Operating Expenses", AccountType.EXPENSE, "income_statement", "debit", None, 300, ["opex", "operating expense", "operating expenses", "general and administrative", "sg&a", "us-gaap:sellinggeneralandadministrativeexpense"]),
             ("depreciation_amortization", "Depreciation & Amortization", AccountType.EXPENSE, "income_statement", "debit", None, 350, ["depreciation", "amortization", "d&a", "us-gaap:depreciationdepletionandamortization"]),
             ("interest_expense", "Interest Expense", AccountType.EXPENSE, "income_statement", "debit", None, 400, ["interest", "interest expense", "us-gaap:interestexpense"]),
             ("tax_expense", "Tax Expense", AccountType.EXPENSE, "income_statement", "debit", None, 500, ["tax", "income tax", "income tax expense", "us-gaap:incometaxexpensebenefit"]),
-            ("cash", "Cash", AccountType.ASSET, "balance_sheet", "debit", None, 1000, ["bank", "cash and cash equivalents", "checking", "savings", "us-gaap:cashandcashequivalentsatcarryingvalue"]),
-            ("accounts_receivable", "Accounts Receivable", AccountType.ASSET, "balance_sheet", "debit", None, 1100, ["accounts receivable", "ar", "a/r", "us-gaap:accountsreceivablenetcurrent"]),
-            ("inventory", "Inventory", AccountType.ASSET, "balance_sheet", "debit", None, 1200, ["inventory", "stock", "us-gaap:inventorynet"]),
-            ("ppe", "Property, Plant & Equipment", AccountType.ASSET, "balance_sheet", "debit", None, 1300, ["fixed assets", "property plant and equipment", "ppe", "pp&e", "us-gaap:propertyplantandequipmentnet"]),
+            ("cash", "Cash", AccountType.ASSET, "balance_sheet", "debit", None, 1000, ["bank", "cash and cash equivalents", "checking", "savings", "undeposited funds", "us-gaap:cashandcashequivalentsatcarryingvalue"]),
+            ("accounts_receivable", "Accounts Receivable", AccountType.ASSET, "balance_sheet", "debit", None, 1100, ["accounts receivable", "accounts receivable a/r", "ar", "a/r", "us-gaap:accountsreceivablenetcurrent"]),
+            ("inventory", "Inventory", AccountType.ASSET, "balance_sheet", "debit", None, 1200, ["inventory", "inventory asset", "stock", "us-gaap:inventorynet"]),
+            ("ppe", "Property, Plant & Equipment", AccountType.ASSET, "balance_sheet", "debit", None, 1300, ["fixed assets", "original cost", "property plant and equipment", "ppe", "pp&e", "us-gaap:propertyplantandequipmentnet"]),
             ("accumulated_depreciation", "Accumulated Depreciation", AccountType.ASSET, "balance_sheet", "credit", None, 1350, ["accumulated depreciation", "us-gaap:accumulateddepreciationdepletionandamortizationpropertyplantandequipment"]),
-            ("accounts_payable", "Accounts Payable", AccountType.LIABILITY, "balance_sheet", "credit", None, 2000, ["accounts payable", "ap", "a/p", "us-gaap:accountspayablecurrent"]),
-            ("accrued_expenses", "Accrued Expenses", AccountType.LIABILITY, "balance_sheet", "credit", None, 2100, ["accrued expenses", "accruals", "accrued liabilities", "us-gaap:accruedliabilitiescurrent"]),
-            ("debt", "Debt", AccountType.LIABILITY, "balance_sheet", "credit", None, 2200, ["loan", "loans", "notes payable", "debt", "long-term debt", "us-gaap:longtermdebtcurrent", "us-gaap:longtermdebtnoncurrent"]),
-            ("equity", "Equity", AccountType.EQUITY, "balance_sheet", "credit", None, 3000, ["owners equity", "owner's equity", "members equity", "stockholders equity", "us-gaap:stockholdersequity"]),
+            ("accounts_payable", "Accounts Payable", AccountType.LIABILITY, "balance_sheet", "credit", None, 2000, ["accounts payable", "accounts payable a/p", "ap", "a/p", "us-gaap:accountspayablecurrent"]),
+            ("accrued_expenses", "Accrued Expenses", AccountType.LIABILITY, "balance_sheet", "credit", None, 2100, ["accrued expenses", "accruals", "accrued liabilities", "arizona dept of revenue payable", "board of equalization payable", "tax payable", "sales tax payable", "us-gaap:accruedliabilitiescurrent"]),
+            ("debt", "Debt", AccountType.LIABILITY, "balance_sheet", "credit", None, 2200, ["loan", "loans", "loan payable", "mastercard", "credit card", "notes payable", "debt", "long-term debt", "us-gaap:longtermdebtcurrent", "us-gaap:longtermdebtnoncurrent"]),
+            ("equity", "Equity", AccountType.EQUITY, "balance_sheet", "credit", None, 3000, ["owners equity", "owner's equity", "opening balance equity", "members equity", "stockholders equity", "us-gaap:stockholdersequity"]),
             ("retained_earnings", "Retained Earnings", AccountType.EQUITY, "balance_sheet", "credit", None, 3100, ["retained earnings", "us-gaap:retainedearningsaccumulateddeficit"]),
             ("net_income", "Net Income", AccountType.CASH_FLOW, "cash_flow_statement", "credit", "operating", 4000, ["net income", "net earnings", "profit", "us-gaap:netincomeloss"]),
             ("depreciation_addback", "Depreciation Add-back", AccountType.CASH_FLOW, "cash_flow_statement", "credit", "operating", 4100, ["depreciation addback", "depreciation and amortization", "us-gaap:depreciationdepletionandamortization"]),
             ("working_capital_movement", "Working Capital Movement", AccountType.CASH_FLOW, "cash_flow_statement", "credit", "operating", 4200, ["change in working capital", "changes in operating assets and liabilities"]),
             ("capex", "Capital Expenditures", AccountType.CASH_FLOW, "cash_flow_statement", "debit", "investing", 5000, ["capex", "capital expenditures", "purchase of property and equipment", "us-gaap:paymentstoacquirepropertyplantandequipment"]),
-            ("financing_movement", "Financing Movement", AccountType.CASH_FLOW, "cash_flow_statement", "credit", "financing", 6000, ["financing activities", "debt proceeds", "debt repayment", "us-gaap:proceedsfromissuanceoflongtermdebt"]),
+            ("financing_movement", "Financing Movement", AccountType.CASH_FLOW, "cash_flow_statement", "credit", "financing", 6000, ["financing activities", "debt proceeds", "debt repayment", "net change in cash", "us-gaap:proceedsfromissuanceoflongtermdebt"]),
         ]
         for account_id, name, account_type, statement, normal_balance, cf_section, order, aliases in account_specs:
             self._add_account(

--- a/src/waccy/modeling/__init__.py
+++ b/src/waccy/modeling/__init__.py
@@ -1,12 +1,12 @@
 """Financial model construction and export."""
 
 from waccy.modeling.builder import ModelBuilder
-from waccy.modeling.exporters import SheetExporter
+from waccy.modeling.exporters import PandasExporter, SheetExporter
 from waccy.modeling.templates import ModelTemplate
 
 __all__ = [
     "ModelBuilder",
     "ModelTemplate",
+    "PandasExporter",
     "SheetExporter",
 ]
-

--- a/src/waccy/modeling/builder.py
+++ b/src/waccy/modeling/builder.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Iterable  # noqa: TC003
 from decimal import Decimal
-from typing import NoReturn
+from typing import Any, Literal, NoReturn
 
 from waccy.core.models import (
     ExtractedData,
@@ -20,7 +20,7 @@ from waccy.core.models import (
 from waccy.core.ontology import StandardChartOfAccounts
 from waccy.core.validation import validate_mapped_dataset
 from waccy.extraction.mapper import DataMapper
-from waccy.modeling.exporters import SheetExporter
+from waccy.modeling.exporters import PandasExporter, SheetExporter
 
 ZERO = Decimal("0")
 
@@ -44,6 +44,7 @@ class ModelBuilder:
         periods = dataset.periods
         period_labels = [period.label for period in periods]
         issues = list(validated.issues)
+        issues.extend(self._source_completeness_issues(dataset.metadata))
 
         income_lines = self._build_income_statement_lines(dataset.records, period_labels)
         balance_lines = self._build_balance_sheet_lines(dataset.records, period_labels)
@@ -91,6 +92,16 @@ class ModelBuilder:
         """Export model to spreadsheet output."""
         exporter = SheetExporter()
         exporter.export(model, output_path)
+
+    def export_to_pandas(
+        self,
+        model: ThreeStatementModel,
+        *,
+        value_type: Literal["decimal", "float"] = "decimal",
+    ) -> dict[str, Any]:
+        """Export model statements to pandas DataFrames."""
+        exporter = PandasExporter()
+        return exporter.export(model, value_type=value_type)
 
     def _ensure_validated(
         self,
@@ -335,4 +346,33 @@ class ModelBuilder:
                         metadata={"difference": str(cash_flow_tie_out.values[period])},
                     )
                 )
+        return issues
+
+    def _source_completeness_issues(self, metadata: dict[str, Any]) -> list[ValidationIssue]:
+        source_issues = metadata.get("qbo_source_issues", [])
+        if not isinstance(source_issues, list):
+            return []
+        issues: list[ValidationIssue] = []
+        for source_issue in source_issues:
+            if not isinstance(source_issue, dict):
+                continue
+            code = str(source_issue.get("code", "source_data_issue"))
+            severity = IssueSeverity(str(source_issue.get("severity", "error")))
+            issues.append(
+                ValidationIssue(
+                    code=code,
+                    message=str(source_issue.get("message", code)),
+                    severity=severity,
+                    period_label=(
+                        str(source_issue["period_label"])
+                        if source_issue.get("period_label") is not None
+                        else None
+                    ),
+                    metadata={
+                        key: value
+                        for key, value in source_issue.items()
+                        if key not in {"code", "message", "severity", "period_label"}
+                    },
+                )
+            )
         return issues

--- a/src/waccy/modeling/builder.py
+++ b/src/waccy/modeling/builder.py
@@ -357,7 +357,11 @@ class ModelBuilder:
             if not isinstance(source_issue, dict):
                 continue
             code = str(source_issue.get("code", "source_data_issue"))
-            severity = IssueSeverity(str(source_issue.get("severity", "error")))
+            try:
+                severity = IssueSeverity(str(source_issue.get("severity", "error")))
+            except ValueError:
+                severity = IssueSeverity.ERROR
+                code = "invalid_source_issue_severity"
             issues.append(
                 ValidationIssue(
                     code=code,

--- a/src/waccy/modeling/exporters.py
+++ b/src/waccy/modeling/exporters.py
@@ -1,11 +1,11 @@
 # mypy: disable-error-code=import-untyped
-"""Export source-agnostic financial models to XLSX workbooks."""
+"""Export source-agnostic financial models to workbooks and DataFrames."""
 
 from __future__ import annotations
 
 from decimal import Decimal
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Literal
 
 from openpyxl import Workbook
 from openpyxl.styles import Font, PatternFill
@@ -70,3 +70,54 @@ class SheetExporter:
         worksheet.column_dimensions["A"].width = 32
         for column in range(2, len(statement.periods) + 2):
             worksheet.column_dimensions[get_column_letter(column)].width = 14
+
+
+class PandasExporter:
+    """Export financial models to pandas DataFrames for follow-on modeling."""
+
+    def export(
+        self,
+        model: ThreeStatementModel,
+        *,
+        value_type: Literal["decimal", "float"] = "decimal",
+    ) -> dict[str, Any]:
+        """Return one DataFrame per financial statement."""
+        return {
+            model.income_statement.name: self._statement_to_frame(
+                model.income_statement, value_type=value_type
+            ),
+            model.balance_sheet.name: self._statement_to_frame(
+                model.balance_sheet, value_type=value_type
+            ),
+            model.cash_flow_statement.name: self._statement_to_frame(
+                model.cash_flow_statement, value_type=value_type
+            ),
+        }
+
+    def _statement_to_frame(
+        self,
+        statement: FinancialStatement,
+        *,
+        value_type: Literal["decimal", "float"],
+    ) -> Any:
+        pd = self._pandas()
+        rows: list[dict[str, Any]] = []
+        for line in statement.lines:
+            row: dict[str, Any] = {
+                "line_item": line.label,
+                "account_id": line.account_id,
+                "is_subtotal": line.is_subtotal,
+                "is_check": line.is_check,
+                "source_account_ids": tuple(line.source_account_ids),
+            }
+            for period in statement.periods:
+                value = line.values.get(period.label, Decimal("0"))
+                row[period.label] = float(value) if value_type == "float" else value
+            rows.append(row)
+        return pd.DataFrame(rows)
+
+    @staticmethod
+    def _pandas() -> Any:
+        import pandas as pd  # noqa: PLC0415
+
+        return pd

--- a/tests/fixtures/qbo_release_smoke_raw.json
+++ b/tests/fixtures/qbo_release_smoke_raw.json
@@ -1,0 +1,191 @@
+{
+  "entity_name": "Sanitized QBO Release Fixture Co",
+  "company_info": {
+    "CompanyInfo": {
+      "CompanyName": "Sanitized QBO Release Fixture Co"
+    }
+  },
+  "accounts": [
+    {"Id": "1", "Name": "Sales", "AccountType": "Income"},
+    {"Id": "2", "Name": "Cost of Goods Sold", "AccountType": "Cost of Goods Sold"},
+    {"Id": "3", "Name": "Operating Expenses", "AccountType": "Expense"},
+    {"Id": "4", "Name": "Depreciation", "AccountType": "Expense"},
+    {"Id": "5", "Name": "Interest Expense", "AccountType": "Expense"},
+    {"Id": "6", "Name": "Income Tax Expense", "AccountType": "Expense"},
+    {"Id": "35", "Name": "Checking", "AccountType": "Bank"},
+    {"Id": "84", "Name": "Accounts Receivable (A/R)", "AccountType": "Accounts Receivable"},
+    {"Id": "81", "Name": "Inventory Asset", "AccountType": "Other Current Asset"},
+    {"Id": "4a", "Name": "Undeposited Funds", "AccountType": "Other Current Asset"},
+    {"Id": "90", "Name": "Original Cost", "AccountType": "Fixed Asset"},
+    {"Id": "91", "Name": "Accumulated Depreciation", "AccountType": "Fixed Asset"},
+    {"Id": "92", "Name": "Accounts Payable (A/P)", "AccountType": "Accounts Payable"},
+    {"Id": "93", "Name": "Arizona Dept. of Revenue Payable", "AccountType": "Other Current Liability"},
+    {"Id": "94", "Name": "Loan Payable", "AccountType": "Long Term Liability"},
+    {"Id": "95", "Name": "Opening Balance Equity", "AccountType": "Equity"},
+    {"Id": "96", "Name": "Retained Earnings", "AccountType": "Equity"}
+  ],
+  "reports": {
+    "2023": {
+      "ProfitAndLoss": {
+        "Header": {
+          "ReportName": "ProfitAndLoss",
+          "StartPeriod": "2023-01-01",
+          "EndPeriod": "2023-12-31",
+          "Currency": "USD",
+          "Option": [{"Name": "NoReportData", "Value": "false"}]
+        },
+        "Rows": {
+          "Row": [
+            {"Header": {"ColData": [{"value": "Income"}, {"value": ""}]}, "Rows": {"Row": [{"type": "Data", "ColData": [{"id": "1", "value": "Sales"}, {"value": "1000"}]}]}, "type": "Section"},
+            {"Header": {"ColData": [{"value": "Cost of Goods Sold"}, {"value": ""}]}, "Rows": {"Row": [{"type": "Data", "ColData": [{"id": "2", "value": "Cost of Goods Sold"}, {"value": "400"}]}]}, "type": "Section"},
+            {"Header": {"ColData": [{"value": "Expenses"}, {"value": ""}]}, "Rows": {"Row": [
+              {"type": "Data", "ColData": [{"id": "3", "value": "Operating Expenses"}, {"value": "200"}]},
+              {"type": "Data", "ColData": [{"id": "4", "value": "Depreciation"}, {"value": "50"}]},
+              {"type": "Data", "ColData": [{"id": "5", "value": "Interest Expense"}, {"value": "20"}]},
+              {"type": "Data", "ColData": [{"id": "6", "value": "Income Tax Expense"}, {"value": "66"}]}
+            ]}, "type": "Section"}
+          ]
+        }
+      },
+      "BalanceSheet": {
+        "Header": {
+          "ReportName": "BalanceSheet",
+          "StartPeriod": "2023-01-01",
+          "EndPeriod": "2023-12-31",
+          "Currency": "USD",
+          "Option": [{"Name": "NoReportData", "Value": "false"}]
+        },
+        "Rows": {
+          "Row": [
+            {"Header": {"ColData": [{"value": "ASSETS"}, {"value": ""}]}, "Rows": {"Row": [
+              {"Header": {"ColData": [{"value": "Current Assets"}, {"value": ""}]}, "Rows": {"Row": [
+                {"type": "Data", "ColData": [{"id": "35", "value": "Checking"}, {"value": "100"}]},
+                {"type": "Data", "ColData": [{"id": "84", "value": "Accounts Receivable (A/R)"}, {"value": "150"}]},
+                {"type": "Data", "ColData": [{"id": "81", "value": "Inventory Asset"}, {"value": "100"}]}
+              ]}, "type": "Section"},
+              {"Header": {"ColData": [{"value": "Fixed Assets"}, {"value": ""}]}, "Rows": {"Row": [
+                {"type": "Data", "ColData": [{"id": "90", "value": "Original Cost"}, {"value": "500"}]},
+                {"type": "Data", "ColData": [{"id": "91", "value": "Accumulated Depreciation"}, {"value": "50"}]}
+              ]}, "type": "Section"}
+            ]}, "type": "Section"},
+            {"Header": {"ColData": [{"value": "LIABILITIES AND EQUITY"}, {"value": ""}]}, "Rows": {"Row": [
+              {"Header": {"ColData": [{"value": "Liabilities"}, {"value": ""}]}, "Rows": {"Row": [
+                {"type": "Data", "ColData": [{"id": "92", "value": "Accounts Payable (A/P)"}, {"value": "120"}]},
+                {"type": "Data", "ColData": [{"id": "93", "value": "Arizona Dept. of Revenue Payable"}, {"value": "80"}]},
+                {"type": "Data", "ColData": [{"id": "94", "value": "Loan Payable"}, {"value": "300"}]}
+              ]}, "type": "Section"},
+              {"Header": {"ColData": [{"value": "Equity"}, {"value": ""}]}, "Rows": {"Row": [
+                {"type": "Data", "ColData": [{"id": "95", "value": "Opening Balance Equity"}, {"value": "36"}]},
+                {"type": "Data", "ColData": [{"id": "96", "value": "Retained Earnings"}, {"value": "264"}]}
+              ]}, "type": "Section"}
+            ]}, "type": "Section"}
+          ]
+        }
+      },
+      "CashFlow": {
+        "Header": {
+          "ReportName": "CashFlow",
+          "StartPeriod": "2023-01-01",
+          "EndPeriod": "2023-12-31",
+          "Currency": "USD",
+          "Option": [{"Name": "NoReportData", "Value": "false"}]
+        },
+        "Rows": {
+          "Row": [
+            {"Header": {"ColData": [{"value": "Operating Activities"}, {"value": ""}]}, "Rows": {"Row": [
+              {"type": "Data", "ColData": [{"value": "Depreciation Addback"}, {"value": "50"}]},
+              {"type": "Data", "ColData": [{"value": "Change in Working Capital"}, {"value": "-20"}]}
+            ]}, "type": "Section"},
+            {"Header": {"ColData": [{"value": "Investing Activities"}, {"value": ""}]}, "Rows": {"Row": [
+              {"type": "Data", "ColData": [{"value": "Capital Expenditures"}, {"value": "-100"}]}
+            ]}, "type": "Section"},
+            {"Header": {"ColData": [{"value": "Financing Activities"}, {"value": ""}]}, "Rows": {"Row": [
+              {"type": "Data", "ColData": [{"value": "Debt Proceeds"}, {"value": "70"}]}
+            ]}, "Summary": {"ColData": [{"value": "Net Change In Cash"}, {"value": "264"}]}, "type": "Section"}
+          ]
+        }
+      }
+    },
+    "2024": {
+      "ProfitAndLoss": {
+        "Header": {
+          "ReportName": "ProfitAndLoss",
+          "StartPeriod": "2024-01-01",
+          "EndPeriod": "2024-12-31",
+          "Currency": "USD",
+          "Option": [{"Name": "NoReportData", "Value": "false"}]
+        },
+        "Rows": {
+          "Row": [
+            {"Header": {"ColData": [{"value": "Income"}, {"value": ""}]}, "Rows": {"Row": [{"type": "Data", "ColData": [{"id": "1", "value": "Sales"}, {"value": "1200"}]}]}, "type": "Section"},
+            {"Header": {"ColData": [{"value": "Cost of Goods Sold"}, {"value": ""}]}, "Rows": {"Row": [{"type": "Data", "ColData": [{"id": "2", "value": "Cost of Goods Sold"}, {"value": "480"}]}]}, "type": "Section"},
+            {"Header": {"ColData": [{"value": "Expenses"}, {"value": ""}]}, "Rows": {"Row": [
+              {"type": "Data", "ColData": [{"id": "3", "value": "Operating Expenses"}, {"value": "240"}]},
+              {"type": "Data", "ColData": [{"id": "4", "value": "Depreciation"}, {"value": "60"}]},
+              {"type": "Data", "ColData": [{"id": "5", "value": "Interest Expense"}, {"value": "25"}]},
+              {"type": "Data", "ColData": [{"id": "6", "value": "Income Tax Expense"}, {"value": "79"}]}
+            ]}, "type": "Section"}
+          ]
+        }
+      },
+      "BalanceSheet": {
+        "Header": {
+          "ReportName": "BalanceSheet",
+          "StartPeriod": "2024-01-01",
+          "EndPeriod": "2024-12-31",
+          "Currency": "USD",
+          "Option": [{"Name": "NoReportData", "Value": "false"}]
+        },
+        "Rows": {
+          "Row": [
+            {"Header": {"ColData": [{"value": "ASSETS"}, {"value": ""}]}, "Rows": {"Row": [
+              {"Header": {"ColData": [{"value": "Current Assets"}, {"value": ""}]}, "Rows": {"Row": [
+                {"type": "Data", "ColData": [{"id": "35", "value": "Checking"}, {"value": "380"}]},
+                {"type": "Data", "ColData": [{"id": "84", "value": "Accounts Receivable (A/R)"}, {"value": "180"}]},
+                {"type": "Data", "ColData": [{"id": "81", "value": "Inventory Asset"}, {"value": "120"}]}
+              ]}, "type": "Section"},
+              {"Header": {"ColData": [{"value": "Fixed Assets"}, {"value": ""}]}, "Rows": {"Row": [
+                {"type": "Data", "ColData": [{"id": "90", "value": "Original Cost"}, {"value": "600"}]},
+                {"type": "Data", "ColData": [{"id": "91", "value": "Accumulated Depreciation"}, {"value": "110"}]}
+              ]}, "type": "Section"}
+            ]}, "type": "Section"},
+            {"Header": {"ColData": [{"value": "LIABILITIES AND EQUITY"}, {"value": ""}]}, "Rows": {"Row": [
+              {"Header": {"ColData": [{"value": "Liabilities"}, {"value": ""}]}, "Rows": {"Row": [
+                {"type": "Data", "ColData": [{"id": "92", "value": "Accounts Payable (A/P)"}, {"value": "140"}]},
+                {"type": "Data", "ColData": [{"id": "93", "value": "Arizona Dept. of Revenue Payable"}, {"value": "90"}]},
+                {"type": "Data", "ColData": [{"id": "94", "value": "Loan Payable"}, {"value": "354"}]}
+              ]}, "type": "Section"},
+              {"Header": {"ColData": [{"value": "Equity"}, {"value": ""}]}, "Rows": {"Row": [
+                {"type": "Data", "ColData": [{"id": "95", "value": "Opening Balance Equity"}, {"value": "270"}]},
+                {"type": "Data", "ColData": [{"id": "96", "value": "Retained Earnings"}, {"value": "316"}]}
+              ]}, "type": "Section"}
+            ]}, "type": "Section"}
+          ]
+        }
+      },
+      "CashFlow": {
+        "Header": {
+          "ReportName": "CashFlow",
+          "StartPeriod": "2024-01-01",
+          "EndPeriod": "2024-12-31",
+          "Currency": "USD",
+          "Option": [{"Name": "NoReportData", "Value": "false"}]
+        },
+        "Rows": {
+          "Row": [
+            {"Header": {"ColData": [{"value": "Operating Activities"}, {"value": ""}]}, "Rows": {"Row": [
+              {"type": "Data", "ColData": [{"value": "Depreciation Addback"}, {"value": "60"}]},
+              {"type": "Data", "ColData": [{"value": "Change in Working Capital"}, {"value": "-50"}]}
+            ]}, "type": "Section"},
+            {"Header": {"ColData": [{"value": "Investing Activities"}, {"value": ""}]}, "Rows": {"Row": [
+              {"type": "Data", "ColData": [{"value": "Capital Expenditures"}, {"value": "-100"}]}
+            ]}, "type": "Section"},
+            {"Header": {"ColData": [{"value": "Financing Activities"}, {"value": ""}]}, "Rows": {"Row": [
+              {"type": "Data", "ColData": [{"value": "Debt Proceeds"}, {"value": "54"}]}
+            ]}, "Summary": {"ColData": [{"value": "Net Change In Cash"}, {"value": "280"}]}, "type": "Section"}
+          ]
+        }
+      }
+    }
+  }
+}

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -30,3 +30,25 @@ def test_standard_chart_of_accounts() -> None:
     ontology = StandardChartOfAccounts()
     assert isinstance(ontology.accounts, dict)
 
+
+def test_qbo_live_smoke_aliases_map_deterministically() -> None:
+    """QBO names surfaced by the live sandbox smoke map into canonical accounts."""
+    ontology = StandardChartOfAccounts()
+    expected = {
+        "Accounts Receivable (A/R)": "accounts_receivable",
+        "Inventory Asset": "inventory",
+        "Undeposited Funds": "cash",
+        "Original Cost": "ppe",
+        "Accounts Payable (A/P)": "accounts_payable",
+        "Mastercard": "debt",
+        "Arizona Dept. of Revenue Payable": "accrued_expenses",
+        "Board of Equalization Payable": "accrued_expenses",
+        "Loan Payable": "debt",
+        "Opening Balance Equity": "equity",
+        "Net Change In Cash": "financing_movement",
+    }
+
+    for source_name, account_id in expected.items():
+        account = ontology.map_account(source_name, "qbo")
+        assert account is not None
+        assert account.id == account_id

--- a/tests/unit/test_quickbooks_client.py
+++ b/tests/unit/test_quickbooks_client.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 import json
 import sys
 from datetime import UTC, date, datetime, timedelta
+from decimal import Decimal
 from pathlib import Path
 from typing import TYPE_CHECKING
-from urllib.error import HTTPError
+from urllib.error import HTTPError, URLError
 
 import pytest
 
@@ -131,6 +132,29 @@ def test_api_client_reports_http_errors() -> None:
         client.get_company_info()
 
 
+def test_api_client_rejects_invalid_account_page_size() -> None:
+    client = QuickBooksApiClient(
+        QuickBooksToken(access_token="access", refresh_token="refresh", realm_id="123")
+    )
+
+    with pytest.raises(ValueError, match="page_size"):
+        client.get_accounts(page_size=0)
+
+
+def test_api_client_reports_url_errors() -> None:
+    def fake_transport(request: Request, timeout: float) -> bytes:
+        del request, timeout
+        raise URLError("network unavailable")
+
+    client = QuickBooksApiClient(
+        QuickBooksToken(access_token="access", refresh_token="refresh", realm_id="123"),
+        transport=fake_transport,
+    )
+
+    with pytest.raises(QuickBooksApiError, match="network unavailable"):
+        client.get_company_info()
+
+
 def test_report_normalizer_converts_nested_qbo_reports_to_fixture() -> None:
     raw_fixture = _release_raw_fixture()
 
@@ -172,6 +196,10 @@ def test_report_normalizer_reports_no_data_and_missing_statements() -> None:
 
     assert {"qbo_report_no_data", "missing_required_source_statement"}.issubset(issue_codes)
     assert fixture["records"] == []
+
+
+def test_report_normalizer_parses_parenthesized_negative_values() -> None:
+    assert QuickBooksReportNormalizer._decimal("(1,234.56)") == Decimal("-1234.56")
 
 
 def _json(payload: dict[str, object]) -> bytes:

--- a/tests/unit/test_quickbooks_client.py
+++ b/tests/unit/test_quickbooks_client.py
@@ -82,6 +82,7 @@ def test_api_client_pulls_company_accounts_and_financial_reports() -> None:
     assert set(pull.reports) == {"ProfitAndLoss", "BalanceSheet", "CashFlow"}
     assert all("sandbox-quickbooks.api.intuit.com" in url for url in seen_urls)
     assert any("start_date=2024-01-01" in url for url in seen_urls)
+    assert any("end_date=2024-12-31" in url for url in seen_urls)
 
 
 def test_api_client_from_token_cache_refreshes_expired_token(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_quickbooks_client.py
+++ b/tests/unit/test_quickbooks_client.py
@@ -17,6 +17,8 @@ if TYPE_CHECKING:
 
 ROOT = Path(__file__).resolve().parents[2]
 QUICKBOOKS_SRC = ROOT / "extensions" / "waccy-quickbooks" / "src"
+if not QUICKBOOKS_SRC.exists():
+    pytest.skip("waccy-quickbooks extension source tree is not available.", allow_module_level=True)
 sys.path.insert(0, str(QUICKBOOKS_SRC))
 
 from waccy_quickbooks import (  # noqa: E402

--- a/tests/unit/test_quickbooks_client.py
+++ b/tests/unit/test_quickbooks_client.py
@@ -1,0 +1,182 @@
+"""Tests for the QuickBooks live-pull support layer."""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import UTC, date, datetime, timedelta
+from pathlib import Path
+from typing import TYPE_CHECKING
+from urllib.error import HTTPError
+
+import pytest
+
+if TYPE_CHECKING:
+    from urllib.request import Request
+
+ROOT = Path(__file__).resolve().parents[2]
+QUICKBOOKS_SRC = ROOT / "extensions" / "waccy-quickbooks" / "src"
+sys.path.insert(0, str(QUICKBOOKS_SRC))
+
+from waccy_quickbooks import (  # noqa: E402
+    FileTokenCache,
+    QuickBooksApiClient,
+    QuickBooksApiError,
+    QuickBooksEnvironment,
+    QuickBooksOAuthConfig,
+    QuickBooksReportNormalizer,
+    QuickBooksToken,
+)
+
+
+def test_file_token_cache_round_trips_token(tmp_path: Path) -> None:
+    token = QuickBooksToken(
+        access_token="access",
+        refresh_token="refresh",
+        realm_id="123",
+        expires_at=datetime.now(UTC) + timedelta(hours=1),
+    )
+    cache = FileTokenCache(tmp_path / "qbo-token.json")
+
+    cache.save(token)
+    loaded = cache.load()
+
+    assert loaded == token
+    assert cache.path.stat().st_mode & 0o777 == 0o600
+
+
+def test_api_client_pulls_company_accounts_and_financial_reports() -> None:
+    seen_urls: list[str] = []
+
+    def fake_transport(request: Request, timeout: float) -> bytes:
+        assert timeout == 30.0
+        assert request.headers["Authorization"] == "Bearer access"
+        seen_urls.append(request.full_url)
+        if "/companyinfo/" in request.full_url:
+            return _json({"CompanyInfo": {"CompanyName": "Fixture QBO Co"}})
+        if "/query?" in request.full_url:
+            return _json({"QueryResponse": {"Account": [{"Id": "1", "Name": "Checking"}]}})
+        if "/reports/ProfitAndLoss" in request.full_url:
+            return _json({"Header": {"ReportName": "ProfitAndLoss"}})
+        if "/reports/BalanceSheet" in request.full_url:
+            return _json({"Header": {"ReportName": "BalanceSheet"}})
+        if "/reports/CashFlow" in request.full_url:
+            return _json({"Header": {"ReportName": "CashFlow"}})
+        raise AssertionError(f"Unexpected URL: {request.full_url}")
+
+    client = QuickBooksApiClient(
+        QuickBooksToken(access_token="access", refresh_token="refresh", realm_id="123"),
+        transport=fake_transport,
+    )
+
+    pull = client.pull_financial_reports(
+        start_date=date(2024, 1, 1),
+        end_date=date(2024, 12, 31),
+    )
+
+    assert pull.entity_name == "Fixture QBO Co"
+    assert pull.accounts == [{"Id": "1", "Name": "Checking"}]
+    assert set(pull.reports) == {"ProfitAndLoss", "BalanceSheet", "CashFlow"}
+    assert all("sandbox-quickbooks.api.intuit.com" in url for url in seen_urls)
+    assert any("start_date=2024-01-01" in url for url in seen_urls)
+
+
+def test_api_client_from_token_cache_refreshes_expired_token(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    expired = QuickBooksToken(
+        access_token="old",
+        refresh_token="refresh",
+        realm_id="123",
+        expires_at=datetime.now(UTC) - timedelta(minutes=1),
+    )
+    refreshed = QuickBooksToken(
+        access_token="new",
+        refresh_token="new-refresh",
+        realm_id="123",
+        expires_at=datetime.now(UTC) + timedelta(hours=1),
+    )
+    cache = FileTokenCache(tmp_path / "qbo-token.json")
+    cache.save(expired)
+
+    class FakeOAuthClient:
+        def __init__(self, config: QuickBooksOAuthConfig) -> None:
+            self.config = config
+
+        def refresh(self, token: QuickBooksToken) -> QuickBooksToken:
+            assert token == expired
+            return refreshed
+
+    monkeypatch.setattr("waccy_quickbooks.client.QuickBooksOAuthClient", FakeOAuthClient)
+
+    client = QuickBooksApiClient.from_token_cache(
+        cache,
+        QuickBooksOAuthConfig(client_id="id", client_secret="secret", redirect_uri="http://localhost"),
+    )
+
+    assert client.token == refreshed
+    assert cache.load() == refreshed
+
+
+def test_api_client_reports_http_errors() -> None:
+    def fake_transport(request: Request, timeout: float) -> bytes:
+        del request, timeout
+        raise HTTPError("https://example.test", 400, "Bad Request", {}, None)
+
+    client = QuickBooksApiClient(
+        QuickBooksToken(access_token="access", refresh_token="refresh", realm_id="123"),
+        QuickBooksEnvironment.PRODUCTION,
+        transport=fake_transport,
+    )
+
+    with pytest.raises(QuickBooksApiError, match="HTTP 400"):
+        client.get_company_info()
+
+
+def test_report_normalizer_converts_nested_qbo_reports_to_fixture() -> None:
+    raw_fixture = _release_raw_fixture()
+
+    fixture = QuickBooksReportNormalizer().to_fixture(raw_fixture)
+
+    assert fixture["entity_name"] == "Sanitized QBO Release Fixture Co"
+    assert [period["label"] for period in fixture["periods"]] == ["2023", "2024"]
+    assert fixture["metadata"]["qbo_source_issues"] == []
+    records = fixture["records"]
+    assert any(
+        record["source_account_name"] == "Accounts Receivable (A/R)"
+        and record["statement"] == "balance_sheet"
+        and record["source_account_type"] == "Accounts Receivable"
+        and record["metadata"]["row_path"] == ["ASSETS", "Current Assets", "Accounts Receivable (A/R)"]
+        for record in records
+    )
+    assert any(
+        record["source_account_name"] == "Net Change In Cash"
+        and record["statement"] == "cash_flow_statement"
+        and record["metadata"]["is_summary_check"]
+        for record in records
+    )
+
+
+def test_report_normalizer_reports_no_data_and_missing_statements() -> None:
+    raw_fixture = _release_raw_fixture()
+    raw_fixture["reports"] = {
+        "2024": {
+            "ProfitAndLoss": raw_fixture["reports"]["2024"]["ProfitAndLoss"],
+        }
+    }
+    raw_fixture["reports"]["2024"]["ProfitAndLoss"]["Header"]["Option"] = [
+        {"Name": "NoReportData", "Value": "true"}
+    ]
+    raw_fixture["reports"]["2024"]["ProfitAndLoss"]["Rows"]["Row"] = []
+
+    fixture = QuickBooksReportNormalizer().to_fixture(raw_fixture)
+    issue_codes = {issue["code"] for issue in fixture["metadata"]["qbo_source_issues"]}
+
+    assert {"qbo_report_no_data", "missing_required_source_statement"}.issubset(issue_codes)
+    assert fixture["records"] == []
+
+
+def _json(payload: dict[str, object]) -> bytes:
+    return json.dumps(payload).encode("utf-8")
+
+
+def _release_raw_fixture() -> dict[str, object]:
+    return json.loads((ROOT / "tests" / "fixtures" / "qbo_release_smoke_raw.json").read_text())

--- a/tests/unit/test_v010_pipeline.py
+++ b/tests/unit/test_v010_pipeline.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import importlib.util
+import json
+import sys
 from decimal import Decimal
 from pathlib import Path
 from types import ModuleType
@@ -27,9 +29,13 @@ from waccy.core.ontology import StandardChartOfAccounts
 from waccy.core.validation import validate_mapped_dataset
 from waccy.extraction.mapper import DataMapper, source_record_from_dict
 from waccy.modeling.builder import ModelBuilder
-from waccy.modeling.exporters import SheetExporter
+from waccy.modeling.exporters import PandasExporter, SheetExporter
 
 ROOT = Path(__file__).resolve().parents[2]
+QUICKBOOKS_SRC = ROOT / "extensions" / "waccy-quickbooks" / "src"
+sys.path.insert(0, str(QUICKBOOKS_SRC))
+
+from waccy_quickbooks import QuickBooksReportNormalizer  # noqa: E402
 
 
 def test_core_dataset_models_round_trip() -> None:
@@ -328,6 +334,72 @@ def test_xlsx_export_writes_three_sheet_workbook(tmp_path: Path) -> None:
         assert cash_flow_statement["C8"].value == 0
     finally:
         workbook.close()
+
+
+def test_pandas_export_returns_statement_dataframes() -> None:
+    """The pandas exporter exposes the same three statements for follow-on modeling."""
+    model = ModelBuilder().build_three_statement_model(_extracted(sample_qbo_fixture(), "qbo"))
+
+    frames = PandasExporter().export(model)
+    float_frames = ModelBuilder().export_to_pandas(model, value_type="float")
+
+    assert list(frames) == ["Income Statement", "Balance Sheet", "Cash Flow Statement"]
+    income_statement = frames["Income Statement"]
+    balance_sheet = frames["Balance Sheet"]
+    assert income_statement.loc[income_statement["line_item"] == "Net Income", "2024"].item() == Decimal(
+        "316"
+    )
+    assert balance_sheet.loc[balance_sheet["line_item"] == "Balance Check", "2024"].item() == Decimal(
+        "0"
+    )
+    assert float_frames["Income Statement"].loc[
+        float_frames["Income Statement"]["line_item"] == "Net Income", "2024"
+    ].item() == 316.0
+
+
+def test_qbo_raw_report_fixture_builds_release_valid_outputs(tmp_path: Path) -> None:
+    """A sanitized QBO raw report fixture reaches XLSX and pandas outputs."""
+    raw_fixture = json.loads((ROOT / "tests" / "fixtures" / "qbo_release_smoke_raw.json").read_text())
+    fixture = QuickBooksReportNormalizer().to_fixture(raw_fixture)
+    extractor_class = _load_extension_class(
+        ROOT / "extensions" / "waccy-quickbooks" / "src" / "waccy_quickbooks" / "extractor.py",
+        "local_waccy_quickbooks_extractor_release",
+        "QuickBooksExtractor",
+    )
+    model = ModelBuilder().build_three_statement_model(
+        extractor_class().extract({"fixture": fixture})
+    )
+    output_path = tmp_path / "qbo-release-smoke.xlsx"
+
+    SheetExporter().export(model, str(output_path))
+    frames = PandasExporter().export(model, value_type="float")
+    workbook = load_workbook(output_path)
+    try:
+        assert workbook.sheetnames == ["Income Statement", "Balance Sheet", "Cash Flow Statement"]
+    finally:
+        workbook.close()
+    assert frames["Income Statement"].loc[
+        frames["Income Statement"]["line_item"] == "Net Income", "2024"
+    ].item() == 316.0
+    assert all(issue.severity != IssueSeverity.ERROR for issue in model.validation_issues)
+
+
+def test_qbo_source_completeness_issues_are_model_errors() -> None:
+    """QBO NoReportData diagnostics become explicit model validation errors."""
+    raw_fixture = json.loads((ROOT / "tests" / "fixtures" / "qbo_release_smoke_raw.json").read_text())
+    raw_fixture["reports"] = {"2024": {"BalanceSheet": raw_fixture["reports"]["2024"]["BalanceSheet"]}}
+    fixture = QuickBooksReportNormalizer().to_fixture(raw_fixture)
+    extracted = ExtractedData(
+        entity_name=str(fixture["entity_name"]),
+        periods=[],
+        source_records=[source_record_from_dict(record, "qbo") for record in fixture["records"]],
+        metadata=fixture["metadata"],
+    )
+    model = ModelBuilder().build_three_statement_model(extracted)
+    issue_codes = {issue.code for issue in model.validation_issues}
+
+    assert "missing_required_source_statement" in issue_codes
+    assert any(issue.severity == IssueSeverity.ERROR for issue in model.validation_issues)
 
 
 def _source_record(account_id: str, account_name: str) -> SourceRecord:

--- a/tests/unit/test_v010_pipeline.py
+++ b/tests/unit/test_v010_pipeline.py
@@ -33,9 +33,13 @@ from waccy.modeling.exporters import PandasExporter, SheetExporter
 
 ROOT = Path(__file__).resolve().parents[2]
 QUICKBOOKS_SRC = ROOT / "extensions" / "waccy-quickbooks" / "src"
-sys.path.insert(0, str(QUICKBOOKS_SRC))
+if QUICKBOOKS_SRC.exists():
+    sys.path.insert(0, str(QUICKBOOKS_SRC))
 
-from waccy_quickbooks import QuickBooksReportNormalizer  # noqa: E402
+try:
+    from waccy_quickbooks import QuickBooksReportNormalizer
+except ModuleNotFoundError:
+    QuickBooksReportNormalizer = None  # type: ignore[assignment]
 
 
 def test_core_dataset_models_round_trip() -> None:
@@ -359,6 +363,8 @@ def test_pandas_export_returns_statement_dataframes() -> None:
 
 def test_qbo_raw_report_fixture_builds_release_valid_outputs(tmp_path: Path) -> None:
     """A sanitized QBO raw report fixture reaches XLSX and pandas outputs."""
+    if QuickBooksReportNormalizer is None:
+        pytest.skip("waccy-quickbooks extension is not importable.")
     raw_fixture = json.loads((ROOT / "tests" / "fixtures" / "qbo_release_smoke_raw.json").read_text())
     fixture = QuickBooksReportNormalizer().to_fixture(raw_fixture)
     extractor_class = _load_extension_class(
@@ -386,6 +392,8 @@ def test_qbo_raw_report_fixture_builds_release_valid_outputs(tmp_path: Path) -> 
 
 def test_qbo_source_completeness_issues_are_model_errors() -> None:
     """QBO NoReportData diagnostics become explicit model validation errors."""
+    if QuickBooksReportNormalizer is None:
+        pytest.skip("waccy-quickbooks extension is not importable.")
     raw_fixture = json.loads((ROOT / "tests" / "fixtures" / "qbo_release_smoke_raw.json").read_text())
     raw_fixture["reports"] = {"2024": {"BalanceSheet": raw_fixture["reports"]["2024"]["BalanceSheet"]}}
     fixture = QuickBooksReportNormalizer().to_fixture(raw_fixture)

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,14 @@
 version = 1
 revision = 3
 requires-python = ">=3.13"
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version < '3.14' and sys_platform == 'emscripten'",
+    "python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
 
 [[package]]
 name = "annotated-types"
@@ -415,6 +423,50 @@ wheels = [
 ]
 
 [[package]]
+name = "pandas"
+version = "3.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "python-dateutil" },
+    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/da/99/b342345300f13440fe9fe385c3c481e2d9a595ee3bab4d3219247ac94e9a/pandas-3.0.2.tar.gz", hash = "sha256:f4753e73e34c8d83221ba58f232433fca2748be8b18dbca02d242ed153945043", size = 4645855, upload-time = "2026-03-31T06:48:30.816Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/ca/3e639a1ea6fcd0617ca4e8ca45f62a74de33a56ae6cd552735470b22c8d3/pandas-3.0.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b5918ba197c951dec132b0c5929a00c0bf05d5942f590d3c10a807f6e15a57d3", size = 10321105, upload-time = "2026-03-31T06:46:57.327Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/77/dbc82ff2fb0e63c6564356682bf201edff0ba16c98630d21a1fb312a8182/pandas-3.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d606a041c89c0a474a4702d532ab7e73a14fe35c8d427b972a625c8e46373668", size = 9864088, upload-time = "2026-03-31T06:46:59.935Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/2b/341f1b04bbca2e17e13cd3f08c215b70ef2c60c5356ef1e8c6857449edc7/pandas-3.0.2-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:710246ba0616e86891b58ab95f2495143bb2bc83ab6b06747c74216f583a6ac9", size = 10369066, upload-time = "2026-03-31T06:47:02.792Z" },
+    { url = "https://files.pythonhosted.org/packages/12/c5/cbb1ffefb20a93d3f0e1fdcda699fb84976210d411b008f97f48bf6ce27e/pandas-3.0.2-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5d3cfe227c725b1f3dff4278b43d8c784656a42a9325b63af6b1492a8232209e", size = 10876780, upload-time = "2026-03-31T06:47:06.205Z" },
+    { url = "https://files.pythonhosted.org/packages/98/fe/2249ae5e0a69bd0ddf17353d0a5d26611d70970111f5b3600cdc8be883e7/pandas-3.0.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:c3b723df9087a9a9a840e263ebd9f88b64a12075d1bf2ea401a5a42f254f084d", size = 11375181, upload-time = "2026-03-31T06:47:09.383Z" },
+    { url = "https://files.pythonhosted.org/packages/de/64/77a38b09e70b6464883b8d7584ab543e748e42c1b5d337a2ee088e0df741/pandas-3.0.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a3096110bf9eac0070b7208465f2740e2d8a670d5cb6530b5bb884eca495fd39", size = 11928899, upload-time = "2026-03-31T06:47:12.686Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/52/42855bf626868413f761addd574acc6195880ae247a5346477a4361c3acb/pandas-3.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:07a10f5c36512eead51bc578eb3354ad17578b22c013d89a796ab5eee90cd991", size = 9746574, upload-time = "2026-03-31T06:47:15.64Z" },
+    { url = "https://files.pythonhosted.org/packages/88/39/21304ae06a25e8bf9fc820d69b29b2c495b2ae580d1e143146c309941760/pandas-3.0.2-cp313-cp313-win_arm64.whl", hash = "sha256:5fdbfa05931071aba28b408e59226186b01eb5e92bea2ab78b65863ca3228d84", size = 9047156, upload-time = "2026-03-31T06:47:18.595Z" },
+    { url = "https://files.pythonhosted.org/packages/72/20/7defa8b27d4f330a903bb68eea33be07d839c5ea6bdda54174efcec0e1d2/pandas-3.0.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:dbc20dea3b9e27d0e66d74c42b2d0c1bed9c2ffe92adea33633e3bedeb5ac235", size = 10756238, upload-time = "2026-03-31T06:47:22.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/95/49433c14862c636afc0e9b2db83ff16b3ad92959364e52b2955e44c8e94c/pandas-3.0.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b75c347eff42497452116ce05ef461822d97ce5b9ff8df6edacb8076092c855d", size = 10408520, upload-time = "2026-03-31T06:47:25.197Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/f8/462ad2b5881d6b8ec8e5f7ed2ea1893faa02290d13870a1600fe72ad8efc/pandas-3.0.2-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d1478075142e83a5571782ad007fb201ed074bdeac7ebcc8890c71442e96adf7", size = 10324154, upload-time = "2026-03-31T06:47:28.097Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/65/d1e69b649cbcddda23ad6e4c40ef935340f6f652a006e5cbc3555ac8adb3/pandas-3.0.2-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5880314e69e763d4c8b27937090de570f1fb8d027059a7ada3f7f8e98bdcb677", size = 10714449, upload-time = "2026-03-31T06:47:30.85Z" },
+    { url = "https://files.pythonhosted.org/packages/47/a4/85b59bc65b8190ea3689882db6cdf32a5003c0ccd5a586c30fdcc3ffc4fc/pandas-3.0.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:b5329e26898896f06035241a626d7c335daa479b9bbc82be7c2742d048e41172", size = 11338475, upload-time = "2026-03-31T06:47:34.026Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/c4/bc6966c6e38e5d9478b935272d124d80a589511ed1612a5d21d36f664c68/pandas-3.0.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:81526c4afd31971f8b62671442a4b2b51e0aa9acc3819c9f0f12a28b6fcf85f1", size = 11786568, upload-time = "2026-03-31T06:47:36.941Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/74/09298ca9740beed1d3504e073d67e128aa07e5ca5ca2824b0c674c0b8676/pandas-3.0.2-cp313-cp313t-win_amd64.whl", hash = "sha256:7cadd7e9a44ec13b621aec60f9150e744cfc7a3dd32924a7e2f45edff31823b0", size = 10488652, upload-time = "2026-03-31T06:47:40.612Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/40/c6ea527147c73b24fc15c891c3fcffe9c019793119c5742b8784a062c7db/pandas-3.0.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:db0dbfd2a6cdf3770aa60464d50333d8f3d9165b2f2671bcc299b72de5a6677b", size = 10326084, upload-time = "2026-03-31T06:47:43.834Z" },
+    { url = "https://files.pythonhosted.org/packages/95/25/bdb9326c3b5455f8d4d3549fce7abcf967259de146fe2cf7a82368141948/pandas-3.0.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0555c5882688a39317179ab4a0ed41d3ebc8812ab14c69364bbee8fb7a3f6288", size = 9914146, upload-time = "2026-03-31T06:47:46.67Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/77/3a227ff3337aa376c60d288e1d61c5d097131d0ac71f954d90a8f369e422/pandas-3.0.2-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:01f31a546acd5574ef77fe199bc90b55527c225c20ccda6601cf6b0fd5ed597c", size = 10444081, upload-time = "2026-03-31T06:47:49.681Z" },
+    { url = "https://files.pythonhosted.org/packages/15/88/3cdd54fa279341afa10acf8d2b503556b1375245dccc9315659f795dd2e9/pandas-3.0.2-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:deeca1b5a931fdf0c2212c8a659ade6d3b1edc21f0914ce71ef24456ca7a6535", size = 10897535, upload-time = "2026-03-31T06:47:53.033Z" },
+    { url = "https://files.pythonhosted.org/packages/06/9d/98cc7a7624f7932e40f434299260e2917b090a579d75937cb8a57b9d2de3/pandas-3.0.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0f48afd9bb13300ffb5a3316973324c787054ba6665cda0da3fbd67f451995db", size = 11446992, upload-time = "2026-03-31T06:47:56.193Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/cd/19ff605cc3760e80602e6826ddef2824d8e7050ed80f2e11c4b079741dc3/pandas-3.0.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:6c4d8458b97a35717b62469a4ea0e85abd5ed8687277f5ccfc67f8a5126f8c53", size = 11968257, upload-time = "2026-03-31T06:47:59.137Z" },
+    { url = "https://files.pythonhosted.org/packages/db/60/aba6a38de456e7341285102bede27514795c1eaa353bc0e7638b6b785356/pandas-3.0.2-cp314-cp314-win_amd64.whl", hash = "sha256:b35d14bb5d8285d9494fe93815a9e9307c0876e10f1e8e89ac5b88f728ec8dcf", size = 9865893, upload-time = "2026-03-31T06:48:02.038Z" },
+    { url = "https://files.pythonhosted.org/packages/08/71/e5ec979dd2e8a093dacb8864598c0ff59a0cee0bbcdc0bfec16a51684d4f/pandas-3.0.2-cp314-cp314-win_arm64.whl", hash = "sha256:63d141b56ef686f7f0d714cfb8de4e320475b86bf4b620aa0b7da89af8cbdbbb", size = 9188644, upload-time = "2026-03-31T06:48:05.045Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/6c/7b45d85db19cae1eb524f2418ceaa9d85965dcf7b764ed151386b7c540f0/pandas-3.0.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:140f0cffb1fa2524e874dde5b477d9defe10780d8e9e220d259b2c0874c89d9d", size = 10776246, upload-time = "2026-03-31T06:48:07.789Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/3e/7b00648b086c106e81766f25322b48aa8dfa95b55e621dbdf2fdd413a117/pandas-3.0.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ae37e833ff4fed0ba352f6bdd8b73ba3ab3256a85e54edfd1ab51ae40cca0af8", size = 10424801, upload-time = "2026-03-31T06:48:10.897Z" },
+    { url = "https://files.pythonhosted.org/packages/da/6e/558dd09a71b53b4008e7fc8a98ec6d447e9bfb63cdaeea10e5eb9b2dabe8/pandas-3.0.2-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4d888a5c678a419a5bb41a2a93818e8ed9fd3172246555c0b37b7cc27027effd", size = 10345643, upload-time = "2026-03-31T06:48:13.7Z" },
+    { url = "https://files.pythonhosted.org/packages/be/e3/921c93b4d9a280409451dc8d07b062b503bbec0531d2627e73a756e99a82/pandas-3.0.2-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b444dc64c079e84df91baa8bf613d58405645461cabca929d9178f2cd392398d", size = 10743641, upload-time = "2026-03-31T06:48:16.659Z" },
+    { url = "https://files.pythonhosted.org/packages/56/ca/fd17286f24fa3b4d067965d8d5d7e14fe557dd4f979a0b068ac0deaf8228/pandas-3.0.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4544c7a54920de8eeacaa1466a6b7268ecfbc9bc64ab4dbb89c6bbe94d5e0660", size = 11361993, upload-time = "2026-03-31T06:48:19.475Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/a5/2f6ed612056819de445a433ca1f2821ac3dab7f150d569a59e9cc105de1d/pandas-3.0.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:734be7551687c00fbd760dc0522ed974f82ad230d4a10f54bf51b80d44a08702", size = 11815274, upload-time = "2026-03-31T06:48:22.695Z" },
+    { url = "https://files.pythonhosted.org/packages/00/2f/b622683e99ec3ce00b0854bac9e80868592c5b051733f2cf3a868e5fea26/pandas-3.0.2-cp314-cp314t-win_amd64.whl", hash = "sha256:57a07209bebcbcf768d2d13c9b78b852f9a15978dac41b9e6421a81ad4cdd276", size = 10888530, upload-time = "2026-03-31T06:48:25.806Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/2b/f8434233fab2bd66a02ec014febe4e5adced20e2693e0e90a07d118ed30e/pandas-3.0.2-cp314-cp314t-win_arm64.whl", hash = "sha256:5371b72c2d4d415d08765f32d689217a43227484e81b2305b52076e328f6f482", size = 9455341, upload-time = "2026-03-31T06:48:28.418Z" },
+]
+
+[[package]]
 name = "pandera"
 version = "0.27.0"
 source = { registry = "https://pypi.org/simple" }
@@ -772,12 +824,22 @@ wheels = [
 ]
 
 [[package]]
+name = "tzdata"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
+]
+
+[[package]]
 name = "waccy"
 version = "0.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },
     { name = "openpyxl" },
+    { name = "pandas" },
     { name = "pandera" },
     { name = "polars" },
     { name = "pydantic" },
@@ -807,6 +869,7 @@ docs = [
 requires-dist = [
     { name = "numpy", specifier = ">=2.3.5" },
     { name = "openpyxl", specifier = ">=3.1.5" },
+    { name = "pandas", specifier = ">=3.0.2" },
     { name = "pandera", specifier = ">=0.27.0" },
     { name = "polars", specifier = ">=1.36.1" },
     { name = "pydantic", specifier = ">=2.12.5" },


### PR DESCRIPTION
## Summary

Implements the QBO release-validity slice for v0.1.0.

- Adds a typed QuickBooks OAuth/report pull layer and file token cache in `waccy-quickbooks`
- Adds `QuickBooksReportNormalizer` to convert raw QBO report JSON into WACCY fixture-shaped source records
- Adds QBO source completeness diagnostics for `NoReportData` and missing/empty required statements
- Adds deterministic aliases surfaced by the live QBO sandbox smoke
- Adds a sanitized raw QBO release smoke fixture that builds a three-sheet workbook and pandas frames
- Keeps core model export working for both XLSX and pandas handoff

Closes #26.
Closes #27.
Closes #28.
Closes #29.

## Validation

- `make pre-push`
  - 44 tests passed
  - coverage 94.42%
  - docs build passed
- `uv run --extra dev mypy src/waccy_quickbooks` from `extensions/waccy-quickbooks` passed

## Smoke notes

Reran the local live QBO sandbox artifacts through the supported normalizer. It now produces XLSX and pandas outputs, and fails for clear source-completeness reasons (`NoReportData` / missing records for P&L and CashFlow), instead of noisy QBO alias misses.

EDGAR issues #22-#25 remain open and are intentionally not part of this PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DecisionNerd/codesmith/waccy/pr/30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * QuickBooks Online extension: OAuth helper, file-backed token cache, live report pulling, report normalizer into fixture-first pipeline, deterministic account mapping, XLSX and pandas DataFrame export for three-statement models
* **Documentation**
  * Expanded README, architecture, and extension docs describing v0.1.0 fixture-first QuickBooks workflow, token-cache guidance, and pandas handoff
* **Tests**
  * Added fixtures and tests covering token cache, API pulls, normalization, pandas export, and end-to-end smoke paths
* **Chores**
  * Added pandas runtime dependency

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DecisionNerd/waccy/pull/30)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->