### PR TITLE
Configure PyPI trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,121 @@
+name: Publish
+
+on:
+  workflow_dispatch:
+    inputs:
+      package:
+        description: Package to publish
+        type: choice
+        required: true
+        default: all
+        options:
+          - all
+          - waccy
+          - waccy-edgar
+          - waccy-quickbooks
+      dry_run:
+        description: Check publish inputs without uploading
+        type: boolean
+        required: true
+        default: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-${{ github.ref }}-${{ inputs.package }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish package distributions
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.13"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
+      - name: Build core
+        if: >
+          inputs.package == 'all' ||
+          inputs.package == 'waccy' ||
+          inputs.package == 'waccy-edgar' ||
+          inputs.package == 'waccy-quickbooks'
+        run: uv build --no-sources
+
+      - name: Smoke test core wheel
+        if: inputs.package == 'all' || inputs.package == 'waccy'
+        run: >
+          uv run --isolated --no-project
+          --with dist/waccy-*.whl
+          -- python -c "from importlib.metadata import version; import waccy; assert waccy.__version__ == version('waccy')"
+
+      - name: Build EDGAR extension
+        if: inputs.package == 'all' || inputs.package == 'waccy-edgar'
+        working-directory: extensions/waccy-edgar
+        run: uv build --no-sources
+
+      - name: Smoke test EDGAR extension wheel
+        if: inputs.package == 'all' || inputs.package == 'waccy-edgar'
+        run: >
+          uv run --isolated --no-project
+          --with dist/waccy-*.whl
+          --with extensions/waccy-edgar/dist/waccy_edgar-*.whl
+          -- python -c "from importlib.metadata import version; import waccy_edgar; assert waccy_edgar.__version__ == version('waccy-edgar')"
+
+      - name: Build QuickBooks extension
+        if: inputs.package == 'all' || inputs.package == 'waccy-quickbooks'
+        working-directory: extensions/waccy-quickbooks
+        run: uv build --no-sources
+
+      - name: Smoke test QuickBooks extension wheel
+        if: inputs.package == 'all' || inputs.package == 'waccy-quickbooks'
+        run: >
+          uv run --isolated --no-project
+          --with dist/waccy-*.whl
+          --with extensions/waccy-quickbooks/dist/waccy_quickbooks-*.whl
+          -- python -c "from importlib.metadata import version; import waccy_quickbooks; assert waccy_quickbooks.__version__ == version('waccy-quickbooks')"
+
+      - name: Publish core
+        if: github.ref == 'refs/heads/main' && (inputs.package == 'all' || inputs.package == 'waccy') && !inputs.dry_run
+        run: uv publish --trusted-publishing always
+
+      - name: Dry-run publish core
+        if: (inputs.package == 'all' || inputs.package == 'waccy') && inputs.dry_run
+        run: uv publish --trusted-publishing automatic --dry-run
+
+      - name: Publish EDGAR extension
+        if: github.ref == 'refs/heads/main' && (inputs.package == 'all' || inputs.package == 'waccy-edgar') && !inputs.dry_run
+        working-directory: extensions/waccy-edgar
+        run: uv publish --trusted-publishing always
+
+      - name: Dry-run publish EDGAR extension
+        if: (inputs.package == 'all' || inputs.package == 'waccy-edgar') && inputs.dry_run
+        working-directory: extensions/waccy-edgar
+        run: uv publish --trusted-publishing automatic --dry-run
+
+      - name: Publish QuickBooks extension
+        if: github.ref == 'refs/heads/main' && (inputs.package == 'all' || inputs.package == 'waccy-quickbooks') && !inputs.dry_run
+        working-directory: extensions/waccy-quickbooks
+        run: uv publish --trusted-publishing always
+
+      - name: Dry-run publish QuickBooks extension
+        if: (inputs.package == 'all' || inputs.package == 'waccy-quickbooks') && inputs.dry_run
+        working-directory: extensions/waccy-quickbooks
+        run: uv publish --trusted-publishing automatic --dry-run

--- a/README.md
+++ b/README.md
@@ -285,6 +285,26 @@ waccy/
 
 See [extensions/README.md](extensions/README.md) for details on working with extensions.
 
+### Trusted Publishing
+
+Package publishing uses GitHub Actions and PyPI Trusted Publishers instead of
+long-lived PyPI API tokens. The workflow is `.github/workflows/publish.yml` and
+uses the GitHub environment `pypi`.
+
+Configure each PyPI project with the same trusted publisher:
+
+| PyPI project | Owner | Repository | Workflow | Environment |
+| --- | --- | --- | --- | --- |
+| `waccy` | `DecisionNerd` | `waccy` | `publish.yml` | `pypi` |
+| `waccy-edgar` | `DecisionNerd` | `waccy` | `publish.yml` | `pypi` |
+| `waccy-quickbooks` | `DecisionNerd` | `waccy` | `publish.yml` | `pypi` |
+
+For existing projects, add the publisher from the project's PyPI
+**Publishing** settings. For a new project, add a pending publisher from the
+account-level PyPI **Publishing** page before the first upload. Keep the
+GitHub `pypi` environment limited to `main`; add required reviewers there when
+the repo needs an explicit human approval gate.
+
 ## 🧪 Testing
 
 ```bash

--- a/docs/3-ARCHITECTURE.md
+++ b/docs/3-ARCHITECTURE.md
@@ -642,8 +642,8 @@ mydatasource = "waccy_mydatasource.extractor:MyDataSourceExtractor"
 
 5. **Publish to PyPI**:
 ```bash
-uv build
-uv publish
+uv build --no-sources
+uv publish --trusted-publishing always
 ```
 
 ## Development Workflow
@@ -684,13 +684,35 @@ uv pip install -e .
 
 ### Building and Publishing
 
+Local builds use uv directly and should disable workspace sources before
+release packaging:
+
 ```bash
 # Build package
-uv build
+uv build --no-sources
 
-# Publish to PyPI (requires credentials)
-uv publish
+# Check upload metadata locally without uploading
+uv publish --dry-run
 ```
+
+Release publishing runs through `.github/workflows/publish.yml` using PyPI
+Trusted Publishers and the GitHub environment `pypi`; no long-lived PyPI token
+is required in GitHub secrets. Configure each PyPI project with:
+
+| PyPI project | Owner | Repository | Workflow | Environment |
+| --- | --- | --- | --- | --- |
+| `waccy` | `DecisionNerd` | `waccy` | `publish.yml` | `pypi` |
+| `waccy-edgar` | `DecisionNerd` | `waccy` | `publish.yml` | `pypi` |
+| `waccy-quickbooks` | `DecisionNerd` | `waccy` | `publish.yml` | `pypi` |
+
+For projects that already exist on PyPI, add the publisher under the project's
+**Publishing** settings. For a first upload of a new project, create a pending
+publisher from the account-level **Publishing** page. The same publisher can be
+registered for multiple PyPI projects in this monorepo.
+
+The GitHub `pypi` environment should be limited to deployments from `main`.
+Add required reviewers to that environment if the release process needs an
+explicit manual approval before upload.
 
 ## Dependency Management
 

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -38,14 +38,25 @@ python scripts/build-extension.py waccy-quickbooks --clean
 
 ### Publishing Extensions
 
-Extensions are published separately to PyPI:
+Extensions are published separately to PyPI through the repository
+`.github/workflows/publish.yml` workflow and PyPI Trusted Publishers. Each
+extension project should trust:
+
+- Owner: `DecisionNerd`
+- Repository: `waccy`
+- Workflow: `publish.yml`
+- Environment: `pypi`
+
+Local publish scripts remain useful for dry-runs and emergency manual releases
+with explicit credentials, but the normal release path should not require a PyPI
+token in GitHub secrets:
 
 ```bash
-# Publish to TestPyPI first
-python scripts/publish-extension.py waccy-quickbooks --testpypi
+# Build locally
+python scripts/build-extension.py waccy-quickbooks --clean
 
-# Publish to PyPI
-python scripts/publish-extension.py waccy-quickbooks --token pypi-<your-token>
+# Check upload metadata locally without uploading
+python scripts/publish-extension.py waccy-quickbooks --dry-run
 ```
 
 ## Creating a New Extension


### PR DESCRIPTION
## Summary
- add a manual GitHub Actions publish workflow for core and first-party extension packages
- use uv build --no-sources and uv publish --trusted-publishing for OIDC-based PyPI publishing
- document the PyPI trusted publisher entries for waccy, waccy-edgar, and waccy-quickbooks

## Repository setup
- created GitHub environment pypi
- limited pypi deployments to the main branch

## Validation
- ruby YAML parse for .github/workflows/publish.yml
- uv build --no-sources for core, waccy-edgar, and waccy-quickbooks
- isolated wheel import smoke tests for core, waccy-edgar, and waccy-quickbooks
- make pre-push
- make docs-build

## PyPI setup still required
Add trusted publishers in PyPI for each project using owner DecisionNerd, repository waccy, workflow publish.yml, and environment pypi.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DecisionNerd/codesmith/waccy/pr/35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated, manually-triggered publishing workflow for core and extension packages with package selection and dry-run support.

* **Documentation**
  * Added guidance for the trusted publishing release process and required environment.
  * Updated build/packaging instructions and extension publishing docs to reflect dry-run checks and trusted publishing workflows.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DecisionNerd/waccy/pull/35)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->