### PR TITLE
Renovate requirements and architecture for polyglot WACCY

### DIFF
--- a/docs/2-REQUIREMENTS.md
+++ b/docs/2-REQUIREMENTS.md
@@ -126,7 +126,8 @@ Requirements:
 - reporting periods
 - normalized records with source provenance
 - amounts, units, currency, and statement hints
-- JSON schema or equivalent machine-readable contract
+- JSON Schema generated from the Python/Pydantic reference models for the first
+  polyglot version
 - stable versioning so Python and Node clients can detect compatibility
 
 ### Mapped Financial Dataset
@@ -288,6 +289,7 @@ Requirements:
 - package versions for Python and Node clients
 - crate versions for Rust packages
 - schema versions for financial datasets
+- root dataset and model outputs include a `schema_version` field
 - ontology versions
 - migration notes when contracts change
 - compatibility tests across Python, Node, and Rust surfaces
@@ -298,7 +300,8 @@ Requirements:
 
 - freeze and version the financial dataset schema
 - define Rust core crate boundaries
-- generate or share schemas with Python and Node clients
+- generate schemas from the Python/Pydantic reference models for Node and Rust
+  consumers
 - preserve current Python v0.1.0 behavior during migration
 - add cross-language fixture conformance tests
 

--- a/docs/2-REQUIREMENTS.md
+++ b/docs/2-REQUIREMENTS.md
@@ -1,228 +1,334 @@
 # WACCY Requirements
 
-This document captures the financial modeling requirements, methods, and deliverables that shape WACCY's roadmap. The v0.1.0 release is intentionally narrower than this full list: it targets QBO/QuickBooks and EDGAR inputs, normalized accounts, a three-statement model, validation checks, and XLSX export.
+WACCY is evolving from a Python-first proof of concept into a multi-language
+financial modeling platform. The product requirement is not "a spreadsheet
+generator in one language." The requirement is a reliable financial data and
+modeling engine that can be embedded from Python, called from Node, and run as a
+Rust-backed service.
 
-## v0.1.0 Release Requirements
+The durable contract remains:
 
-The first useful release should prove the core modeling loop with a narrow, testable vertical slice:
+```text
+source data
+  -> normalized financial dataset
+  -> mapped financial dataset
+  -> validated financial dataset
+  -> model and metric outputs
+  -> exports and downstream APIs
+```
 
-- load QBO/QuickBooks fixture data
-- load EDGAR fixture data
-- produce a normalized financial dataset from both sources
-- normalize source accounts and concepts into WACCY standard accounts
-- validate the mapped financial dataset before model construction
-- build a three-statement model object
-- export an `.xlsx` workbook with Income Statement, Balance Sheet, and Cash Flow Statement sheets
-- report unmapped accounts, missing periods, balance-sheet imbalance, and cash-flow tie-out failures
-- include fixture-driven tests for the full path from source data to workbook
+The language surfaces must share this contract instead of inventing separate
+data shapes.
 
-Live integrations can be documented behind clear configuration paths, but fixtures are enough to prove the v0.1.0 modeling loop.
+## Product Scope
 
-## Data Quality Requirements
+WACCY should help developers and analysts turn messy accounting, filing, and
+operational data into auditable financial datasets and model outputs. The first
+release proved a three-statement vertical slice. The next architecture should
+support many model types, multiple runtimes, and a more durable backend.
 
-WACCY must make data quality measurable and reviewable:
+Required product outcomes:
 
-- normalized records should preserve source provenance before mapping
-- every model line item should trace back to source data
-- every source account or concept should map to a canonical WACCY account or appear in diagnostics
-- mappings should carry confidence or review status
-- validation should catch structurally invalid data before model construction
-- reconciliation should catch broken statements after model construction
-- users should be able to inspect and override ambiguous classifications
+- load source data from accounting systems, filings, fixtures, and future
+  operational sources
+- preserve source provenance from extraction through output
+- normalize source records into a stable financial dataset contract
+- map source accounts and concepts into a canonical WACCY ontology
+- validate completeness, balance checks, cash-flow tie-outs, and mapping quality
+- build source-agnostic financial models and metrics
+- export to XLSX, pandas, JSON, and API-friendly structures
+- support Python and Node developers without duplicating modeling logic
+- run deterministic, performance-sensitive logic in Rust
 
-Quality reporting should prioritize actionability over ornamental scores.
+## API Surface Requirements
 
-## Layer Requirements
+WACCY should expose the same platform through multiple API surfaces.
 
-The v0.1.0 implementation should establish the reusable layers that future financial models and metrics will depend on:
+### Python API
 
-- **Raw extracted data**: source-shaped records with provenance.
-- **Normalized financial dataset**: source-agnostic records with periods, accounts or concepts, amounts, units, source system, and provenance.
-- **Mapped financial dataset**: normalized records connected to WACCY standard accounts with confidence and review status.
-- **Validated financial dataset**: mapped records plus diagnostics and reconciliation results.
-- **Model and metric outputs**: source-agnostic builders that consume validated data.
-- **Exports**: rendered workbook or other output formats.
+The Python API is for analysts, data scientists, notebooks, backend workers, and
+existing Python finance/data ecosystems.
 
-Extractors should not build financial models. Model and metric builders should not depend on source-specific QBO or EDGAR structures.
+Requirements:
 
-## Standardization Requirements
+- idiomatic Python package install and imports
+- typed models or schema-generated classes for financial datasets
+- pandas handoff for downstream modeling and analysis
+- XLSX export support
+- fixture-first and file-based workflows
+- compatibility path for the current `waccy`, `waccy-edgar`, and
+  `waccy-quickbooks` users
 
-All financial data must pass through a standard ontology before it becomes model output. The ontology should support:
+The Python API should become a thin orchestration and ergonomics layer over the
+shared contract and Rust-backed core logic where practical.
+
+### Node API
+
+The Node API is for web apps, SaaS backends, agent tools, serverless workflows,
+and JavaScript/TypeScript product teams.
+
+Requirements:
+
+- published npm package with TypeScript types
+- JSON-serializable request and response contracts
+- model-building, validation, and export APIs equivalent to Python where
+  applicable
+- browser-safe or server-only boundaries documented clearly
+- streaming or async-friendly interfaces for larger jobs
+- compatibility with web application frameworks without requiring Python
+
+The Node API should not reimplement financial logic independently. It should call
+the same Rust backend or generated bindings/contracts.
+
+### Rust Backend
+
+Rust is the canonical backend for deterministic computation, validation,
+mapping, and performance-sensitive model assembly.
+
+Requirements:
+
+- shared financial dataset schema and ontology types
+- deterministic mapping and validation engine
+- model builders for three-statement models and future model families
+- stable serialization format for Python, Node, and service APIs
+- test coverage for core financial invariants
+- clear FFI, WebAssembly, or service boundary depending on deployment mode
+
+Rust should own the parts where correctness, speed, and cross-language reuse
+matter most. Source-specific API clients may remain in Python or Node if that is
+where the ecosystem is strongest.
+
+## Data Contract Requirements
+
+All APIs must support the same conceptual data layers.
+
+### Source Data
+
+Source data is source-shaped and provenance-rich. It may come from QBO, EDGAR,
+spreadsheets, PDFs, customer uploads, or future operational systems.
+
+Requirements:
+
+- source system and source record identifiers
+- source labels, account names, concepts, and metadata
+- period labels, dates, units, currency, and statement hints
+- raw payload references where safe
+- diagnostics for missing, empty, or partial source reports
+
+### Normalized Financial Dataset
+
+The normalized dataset is the shared cross-language input to mapping and
+validation.
+
+Requirements:
+
+- entity metadata
+- reporting periods
+- normalized records with source provenance
+- amounts, units, currency, and statement hints
+- JSON schema or equivalent machine-readable contract
+- stable versioning so Python and Node clients can detect compatibility
+
+### Mapped Financial Dataset
+
+The mapped dataset connects normalized records to WACCY canonical accounts.
+
+Requirements:
+
+- canonical account identifiers
+- mapping status: mapped, ambiguous, overridden, unmapped
+- confidence score and diagnostics
+- override metadata
+- source provenance preserved
+
+### Validated Financial Dataset
+
+The validated dataset is the required input to source-agnostic model builders.
+
+Requirements:
+
+- validation issues with severity, period, account, and source references
+- reconciliation checks
+- completeness diagnostics
+- machine-readable status for API consumers
+- human-readable diagnostics for review workflows
+
+## Ontology Requirements
+
+The WACCY ontology is the canonical financial vocabulary across languages.
+
+Requirements:
 
 - account type and hierarchy
 - statement placement
-- normal balance/sign convention
+- normal balance and sign convention
 - cash-flow classification
-- source aliases for QBO account names and EDGAR/XBRL concepts
-- industry-specific extension without fragmenting the standard
+- QBO aliases and EDGAR/XBRL aliases
+- industry extension points
+- versioned schema and migration path
 
-The ontology is a product requirement, not only an implementation detail: without standardization, WACCY cannot compare companies, quantify mapping quality, or generate reliable downstream models.
+The ontology should be generated or shared across Python, Node, and Rust so
+there is one source of truth.
 
-## Financial Modeling Skills, Methods, And Model Types
+## Model Requirements
 
-### Model engineering and spreadsheet craft
+Model builders should consume validated datasets and produce source-agnostic
+outputs.
 
-*Note: v0.1.0 targets XLSX export. Google Sheets support is a longer-term output option.*
+Required model families:
 
-* **Model architecture**: modular tabs, inputs/assumptions separation, consistent time axis, sign conventions, hardcode isolation
-* **Formatting standards**: color conventions, units (000s/MM), date handling, print-ready layouts
-* **Formula design**: robust links, avoiding fragile offsets, transparent logic, minimizing circularity
-* **Speed and scale**: efficient formulas, calc settings, iterative calc controls, performance hygiene
-* **Auditability**: check rows, balance checks, roll-forwards, flags, reconciliation tables, trace precedents/dependents
-* **Scenario tooling**: data tables, scenario toggles, switch cases, goal seek, solver, sensitivity matrices, tornado charts
-* **Advanced spreadsheet tools** (optional but common in practice): pivot tables, named ranges, dynamic arrays (ARRAYFORMULA/LAMBDA in Google Sheets), query functions, Apps Script for automation (Google Sheets equivalent of VBA/macros)
-
-### Accounting and financial statement analysis (skills)
-
-* **Income statement mechanics**: revenue recognition basics, COGS vs opex classification, margin stack, SBC, non-recurring items
-* **Balance sheet mechanics**: working capital accounts, deferred revenue, accrued expenses, debt vs equity classification, lease accounting awareness
-* **Cash flow mechanics**: indirect method, non-cash add-backs, NWC bridge, capex vs opex, financing/investing classification
-* **Quality of earnings**: normalization adjustments, run-rate vs reported, one-time costs, restructuring, FX impacts
-* **Ratio and returns**: ROIC/ROE/ROA, DuPont, margin/turnover, leverage, coverage, liquidity
-* **Credit lens**: leverage ratios, fixed-charge coverage, covenant math, debt capacity framing
-
-### Forecasting methods (drivers, not vibes)
-
-* **Revenue builds**: price × volume, units × ARPU, cohort/retention models (SaaS), pipeline conversion, capacity-based revenue
-* **Cost builds**: variable vs fixed cost frameworks, headcount models, gross margin drivers, opex by function, inflation indexing
-* **Working capital**: DSO/DIO/DPO, % of revenue, seasonality, inventory turns, deferred revenue dynamics
-* **Capex & depreciation**: capex by category, asset lives, depreciation waterfalls, capitalized software
-* **Debt & interest**: revolver mechanics, fixed/floating rate modeling, spreads, amortization schedules, cash sweep waterfalls
-* **Equity & shares**: basic/diluted share count, treasury stock method, convertibles, RSUs/options, buybacks/issuance
-* **Taxes**: effective tax rate vs statutory, deferred taxes (DTAs/DTLs), NOL utilization, interest limitation awareness
-* **Segment and geography**: segment KPIs, mix shift, FX translation, margin differences by segment
-
-### Core valuation methods
-
-* **DCF (intrinsic valuation)**
-
-  * Unlevered FCF construction (NOPAT + D&A − Capex − ΔNWC)
-  * Discounting mechanics (stub periods, mid-year convention)
-  * Terminal value (perpetuity growth, exit multiple)
-  * Enterprise → equity bridge (net debt, minority interest, investments, preferred)
-  * WACC build (cost of equity, cost of debt, target capital structure)
-* **Relative valuation**
-
-  * Trading comps (peer selection, spreading, normalization, EV/Revenue, EV/EBITDA, P/E, sector metrics)
-  * Transaction comps (precedent deals, implied multiples, control premiums, deal adjustments)
-* **Common “extras”**
-
-  * **Sum-of-the-parts (SOTP)**, **implied multiple triangulation**, **football field outputs**
-  * **APV** (Adjusted Present Value) for leverage/tax shield clarity
-  * **Residual income / economic profit** frameworks (less common but useful in some cases)
-
-### M&A and pro forma analysis methods
-
-* **Accretion/dilution**: pro forma EPS impact, synergy timing, financing mix sensitivities
-* **Sources & uses**: cash/stock/debt mix, fees, refinancing, rollover equity
-* **Purchase accounting / PPA**: goodwill, intangibles, step-ups, deferred taxes, amortization impacts
-* **Deal structures**: fixed vs floating exchange ratio, collars, contingent consideration/earn-outs (when applicable)
-* **Synergy modeling**: cost vs revenue synergies, phasing, one-time integration costs, dis-synergies
-* **Contribution analysis**: relative ownership, value transfer, synergy split logic
-* **Pro forma statements**: combined IS/BS/CF with transaction adjustments and financing effects
-
-### LBO and private equity modeling methods
-
-* **Returns math**: IRR, MOIC (multiple on invested capital), cash-on-cash
-* **Capital structure**: senior/mezz/notes/PIK, revolver, management rollover, preferred equity
-* **Debt schedules**: mandatory amortization, cash sweep, refinancing, call protection (high-yield awareness)
-* **Interest modeling**: fixed vs floating, SOFR/LIBOR + spread, blended rates, average balance conventions
-* **Tax effects**: interest shield, NOLs, limitations awareness, cash tax vs book tax framing
-* **Exit analysis**: exit multiple, IPO/strategic/secondary, deleveraging effects, dividend recap modeling
-* **Sensitivity grids**: entry/exit multiple, leverage, EBITDA growth, margin, hold period, rate environment
-
-### Data sourcing, standardization, and “spreading”
-
-* **Primary sources**: 10-K/10-Q/8-K, proxy statements, earnings releases, presentations, call transcripts
-* **Normalization and adjustments**: GAAP ↔ non-GAAP reconciliation, run-rate adjustments, segment restatements
-* **Consistency work**: calendarization, LTM building, pro forma adjustments, currency and FX handling
-* **Market data integration**: share price, shares outstanding, debt pricing, yield curves/spreads (as needed)
-
-### Presentation and decision-support outputs
-
-* **Valuation summaries**: ranges, quartiles/medians, implied valuations, key assumptions callouts
-* **Charts & tables**: comps tables, sensitivity tables, bridge charts (EV→Eq), debt waterfalls, return bridges
-* **Narrative framing**: investment highlights, key risks, diligence questions, KPI dashboards
-
----
-
-## Common model types (deliverables)
-
-* **3-statement integrated operating model**
-* **DCF valuation model**
-* **Trading comps model**
-* **Transaction comps model**
-* **Merger model (accretion/dilution + purchase accounting)**
-* **LBO model**
-* **SOTP / break-up valuation model**
-* **Cap table & dilution model (options/convertibles)**
-* **Credit / covenant compliance model**
-* **Budget vs actual / forecast (FP&A) model**
-* **Project finance / infrastructure model (cash waterfall, DSCR/LLCR)**
-* **Real estate (REIT) / property cash flow model**
-* **SaaS cohort + unit economics model**
-* **Carve-out / spin / restructuring model (when relevant)**
-
-## Phased Roadmap Requirements
-
-### Phase One: Core Foundation And Three-Statement Models
-
-Objective: establish the foundational platform with QBO/QuickBooks and EDGAR fixture-supported extraction, standardized ontology, basic account mapping, model generation, validation, and XLSX export.
-
-Required capabilities:
-
-- core platform architecture with a modular data-source interface
-- minimum WACCY chart of accounts for three-statement modeling
-- deterministic mapping from QBO accounts and EDGAR/XBRL concepts
-- three-statement model generation
-- reconciliation checks and quality diagnostics
-- fixture-driven tests for both QBO and EDGAR paths
-
-### Phase Two: Public Market Data And Pattern Learning
-
-Objective: use SEC EDGAR as both public-company source data and a corpus of professional classification examples.
-
-Required capabilities:
-
-- richer EDGAR extraction from 10-K, 10-Q, and 8-K filings
-- normalization and calendarization of public company periods
-- pattern extraction for classification and causal-chain learning
-- comparison workflows that help interpret small-business data through better-documented examples
-
-### Phase Three: Advanced Valuation Models
-
-Objective: build valuation and transaction analysis on top of standardized three-statement outputs.
-
-Required capabilities:
-
-- DCF valuation
+- three-statement operating model
+- DCF valuation model
 - trading comparables
 - transaction comparables
-- M&A and pro forma analysis
-- LBO model generation
-- sensitivity and scenario tooling
+- M&A and pro forma model
+- LBO model
+- credit and covenant model
+- SaaS cohort and unit economics model
+- FP&A budget vs actual model
 
-### Phase Four: Specialized Model Types
+The three-statement model remains the foundation. Future models should reuse its
+validated data, period handling, sign conventions, and export infrastructure.
 
-Objective: extend WACCY into industry and use-case-specific models.
+## Export And Downstream Requirements
 
-Required capabilities:
+WACCY must support both human review and programmatic handoff.
 
-- SaaS cohort and unit economics models
-- real estate and REIT models
-- project finance and infrastructure models
-- cap table and dilution analysis
-- credit and covenant compliance models
-- industry-specific template libraries
+Required outputs:
 
-### Phase Five: Advanced Analysis And Decision Support
+- XLSX workbooks with visible checks
+- pandas DataFrames for Python workflows
+- JSON responses for APIs and Node workflows
+- stable model objects for service consumers
+- diagnostics suitable for UI display
 
-Objective: help users reason across scenarios, risks, and fragmented sources.
+Optional future outputs:
 
-Required capabilities:
+- Google Sheets
+- Arrow/Parquet
+- DuckDB-compatible tables
+- BI/dashboard payloads
 
-- multi-scenario model generation
-- automated sensitivity analysis
-- strategic planning models
-- source synthesis from documents and operational systems
-- confidence-aware decision-support outputs
+## Quality Requirements
+
+Financial correctness must be measurable and testable.
+
+Requirements:
+
+- source records trace to model lines
+- unmapped and ambiguous records are visible
+- required periods are detected and validated
+- duplicate or malformed periods are rejected
+- balance-sheet imbalances are reported
+- cash-flow tie-outs are reported
+- generated outputs include check rows or equivalent diagnostics
+- Python, Node, and Rust tests share fixture expectations where possible
+
+Quality reporting should prioritize actions a user or developer can take.
+
+## Source Requirements
+
+### QBO / QuickBooks
+
+QBO remains the primary small-business accounting source.
+
+Requirements:
+
+- raw report JSON normalization
+- chart of accounts metadata
+- ProfitAndLoss, BalanceSheet, and CashFlow handling
+- empty or partial report diagnostics
+- deterministic aliases for common sandbox and live account names
+- live pull tooling outside the core modeling engine
+
+### SEC EDGAR
+
+EDGAR remains the primary public-company filing source and pattern corpus.
+
+Requirements:
+
+- company facts ingestion
+- XBRL concept mapping
+- period selection and date handling
+- deterministic pattern learning for classification support
+- diagnostics for partial filings or incomplete statement coverage
+
+### Future Sources
+
+Future source packages should be able to target any supported API surface as long
+as they emit the shared normalized dataset.
+
+Likely sources:
+
+- Xero, Sage, NetSuite, and other accounting systems
+- banking, payments, and payroll systems
+- spreadsheets and uploaded workbooks
+- PDFs and financial documents
+- market data providers
+- CRM and sales systems
+
+## Runtime Requirements
+
+The platform should support multiple deployment modes:
+
+- local Python package workflows
+- Node server workflows
+- Rust CLI or service workflows
+- hosted API service
+- batch jobs for large filings or portfolios
+
+The same model and validation logic should be reusable across these modes.
+
+## Versioning Requirements
+
+WACCY should version contracts deliberately.
+
+Requirements:
+
+- package versions for Python and Node clients
+- crate versions for Rust packages
+- schema versions for financial datasets
+- ontology versions
+- migration notes when contracts change
+- compatibility tests across Python, Node, and Rust surfaces
+
+## Roadmap Requirements
+
+### Phase One: Multi-Language Contract Foundation
+
+- freeze and version the financial dataset schema
+- define Rust core crate boundaries
+- generate or share schemas with Python and Node clients
+- preserve current Python v0.1.0 behavior during migration
+- add cross-language fixture conformance tests
+
+### Phase Two: Rust Core Parity
+
+- port deterministic ontology, mapping, validation, and period logic to Rust
+- expose Rust through Python bindings and Node bindings or a service API
+- prove parity against existing QBO and EDGAR fixtures
+- keep XLSX and pandas handoff available from Python
+
+### Phase Three: Service And Node API
+
+- publish TypeScript package
+- expose model-building and validation APIs for web backends
+- support async job execution for larger datasets
+- add JSON-first diagnostics for product UIs
+
+### Phase Four: Advanced Models
+
+- DCF
+- comparables
+- transaction and M&A models
+- LBO
+- credit/covenant
+- SaaS and FP&A models
+
+### Phase Five: Decision Support
+
+- scenario management
+- sensitivity analysis
+- model comparison
+- document and source synthesis
+- confidence-aware review workflows

--- a/docs/3-ARCHITECTURE.md
+++ b/docs/3-ARCHITECTURE.md
@@ -39,9 +39,15 @@ The current Python implementation is the reference behavior for the first
 vertical slice: QBO and EDGAR inputs, canonical mapping, validation,
 three-statement model output, XLSX export, and pandas handoff.
 
-The next architecture should treat that Python implementation as a working
+For the first polyglot version, the Python/Pydantic data models are also the
+schema authority. Checked-in JSON Schema artifacts are generated from those
+models so Node, Rust, hosted services, and source adapters can align on the same
+contract without reimplementing the shape by hand.
+
+The next architecture should treat that Python implementation as the working
 reference, not as the final core boundary. Rust should become the canonical
-engine as parity is established.
+engine only after parity against the Pydantic schemas and v0.1.0 behavior is
+established.
 
 ## Architectural Principles
 
@@ -148,6 +154,10 @@ waccy/
 This is a target shape, not an immediate requirement to move every file. The
 first migration should avoid churn until Rust and Node boundaries are clear.
 
+The initial `schemas/` artifacts are generated from Pydantic. They are committed
+so non-Python consumers can depend on stable files, and drift checks should fail
+when the Python contract changes without regenerating schemas.
+
 ## Rust Backend
 
 Rust should become the canonical engine for financial correctness and
@@ -195,6 +205,10 @@ Rust should accept and emit versioned structures:
 Serialization should be stable enough for Python and Node wrappers to rely on.
 JSON Schema is the most practical contract format for cross-language alignment;
 Arrow or binary formats can be added for large datasets later.
+
+During Phase One, Rust consumes the Pydantic-generated schemas as fixtures and
+compatibility targets. Rust-generated schemas can replace Pydantic as the
+authority only after the Rust core proves parity and the migration is documented.
 
 ## Python API
 
@@ -414,7 +428,7 @@ sequences.
   hosted service first?
 - Should source adapters remain in Python packages or move toward language-
   specific SDKs?
-- Should schemas be generated from Rust types or maintained as independent JSON
-  Schema files?
+- After Rust parity, should schemas continue to be generated from Pydantic,
+  switch to Rust-generated artifacts, or move to an independent schema package?
 - What package names should be reserved for npm and crates.io?
 - How much of XLSX export should stay in Python versus move to Rust or Node?

--- a/docs/3-ARCHITECTURE.md
+++ b/docs/3-ARCHITECTURE.md
@@ -2,26 +2,66 @@
 
 ## Overview
 
-WACCY is designed as a core platform with a modular extension architecture. The core platform (`waccy`) provides the foundation—standardized data ontology, model generation frameworks, and extension interfaces—while extension packages (`waccy-*`) implement specific data source integrations and specialized functionality. This architecture enables:
+WACCY is moving toward a polyglot architecture:
 
-- **Focused Core**: A simple, maintainable core platform with essential functionality
-- **Modular Extensions**: Community-developed and third-party extension packages
-- **Clean Separation**: Core platform logic independent of data source implementations
-- **Easy Distribution**: Both core and extensions publishable to PyPI independently
+- **Rust backend**: canonical deterministic engine for schemas, ontology,
+  mapping, validation, and model construction.
+- **Python API**: analyst and data-science surface, pandas/XLSX integration, and
+  compatibility path for the existing Python package.
+- **Node API**: TypeScript surface for web apps, SaaS products, agent tools, and
+  server-side JavaScript workflows.
+
+The architectural goal is one financial modeling contract with multiple
+language-native entry points.
+
+```text
+Python API         Node API          Hosted/API clients
+    \                |                 /
+     \               |                /
+      -> shared schema and transport ->
+                    |
+              Rust backend
+                    |
+      ontology, mapping, validation, models
+                    |
+       exports, diagnostics, model outputs
+```
 
 ## Current Implementation Status
 
-This document describes both the intended architecture and the current scaffold. As of the v0.1.0 release candidate package set:
+The published v0.1.0 release is Python-first:
 
 - `waccy` is `0.1.0`
-- `waccy-quickbooks` is `0.1.1`
 - `waccy-edgar` is `0.1.0`
+- `waccy-quickbooks` is `0.1.1`
 
-The repository currently contains the core interfaces, public package exports, extension discovery, placeholder extractors, and build/publish tooling. The end-to-end workflow is tracked for [v0.1.0](https://github.com/DecisionNerd/waccy/milestone/1): QBO/QuickBooks and EDGAR inputs, canonical mapping, a three-statement model object, and XLSX export.
+The current Python implementation is the reference behavior for the first
+vertical slice: QBO and EDGAR inputs, canonical mapping, validation,
+three-statement model output, XLSX export, and pandas handoff.
+
+The next architecture should treat that Python implementation as a working
+reference, not as the final core boundary. Rust should become the canonical
+engine as parity is established.
+
+## Architectural Principles
+
+- **One contract, many APIs**: Python and Node should expose the same financial
+  dataset and model concepts.
+- **Rust owns deterministic logic**: schema validation, ontology mapping,
+  reconciliation, and model assembly should converge in Rust.
+- **Source adapters stay pragmatic**: QBO, EDGAR, and future source clients can
+  live in the language with the best ecosystem, as long as they emit the shared
+  normalized dataset.
+- **No duplicated financial rules**: Python and Node wrappers should not drift
+  into separate financial engines.
+- **API-first diagnostics**: validation and mapping issues should be structured
+  enough for CLIs, notebooks, web UIs, and hosted APIs.
+- **Migration without breakage**: current Python users should keep a coherent
+  path while internals move toward Rust.
 
 ## Layered Data Contract
 
-WACCY should keep extraction, normalization, modeling, metrics, and export as separate layers. The v0.1.0 implementation should make these contracts explicit so future model types can reuse the same normalized financial data.
+The durable WACCY pipeline remains:
 
 ```text
 source extractor
@@ -30,800 +70,351 @@ source extractor
   -> mapped financial dataset
   -> validated financial dataset
   -> model and metric builders
-  -> exporters
+  -> exporters and API responses
 ```
 
 ### Source Extractor
 
-An extractor is source-specific. It knows how to read QBO, EDGAR, or another system and return source records with provenance. It should not know how to build a three-statement model.
+Extractors are source-specific. They read QBO, EDGAR, or another source and
+return source records with provenance. Extractors should not build financial
+models.
 
 ### Raw Extracted Data
 
-Raw extracted data preserves source-native concepts: account names, account IDs, statement labels, transaction IDs, dates, periods, units, and source metadata. This layer is useful for auditability and debugging.
+Raw extracted data preserves source-native concepts: account names, account IDs,
+statement labels, transaction IDs, dates, periods, units, and metadata. This is
+the audit and debugging layer.
 
 ### Normalized Financial Dataset
 
-The normalized financial dataset is the reusable contract between extraction and downstream analysis. It should represent source records in a consistent shape: periods, entities, accounts or concepts, amounts, units, source system, and provenance. It is still allowed to contain source-native account IDs and concepts.
-
-This layer is what lets WACCY support future metric extraction and model types without rewriting extractors.
+The normalized dataset is the cross-language contract between extraction and
+downstream analysis. It should be serializable and versioned so Python, Node, and
+Rust all agree on its shape.
 
 ### Mapped Financial Dataset
 
-The mapped dataset connects normalized records to the WACCY ontology. It adds canonical account IDs, confidence, review status, ambiguity diagnostics, and optional user overrides.
+The mapped dataset connects normalized records to the WACCY ontology. It adds
+canonical account IDs, confidence, review status, ambiguity diagnostics, and
+optional user overrides.
 
 ### Validated Financial Dataset
 
-The validated dataset adds quality and reconciliation results: missing periods, unmapped accounts, balance checks, cash-flow tie-outs, and other diagnostics. Model and metric builders should consume this layer rather than raw source data.
+The validated dataset adds quality and reconciliation results. Model and metric
+builders should consume this layer rather than raw source data.
 
 ### Model And Metric Builders
 
-Builders should be source-agnostic. A three-statement model builder, DCF builder, SaaS metric extractor, covenant calculator, or comparables spreader should consume the validated dataset and ontology metadata rather than source-specific QBO or EDGAR structures.
+Builders are source-agnostic. Three-statement, DCF, comparables, SaaS metrics,
+covenants, and LBO builders should consume validated datasets and ontology
+metadata.
 
-### Exporters
+### Exporters And API Responses
 
-Exporters render model or metric outputs into files or external systems. v0.1.0 targets XLSX workbook export; other output targets can be added later without changing extractor contracts.
+Exporters render model or metric outputs into files or external systems. The
+same output object should support XLSX, pandas, JSON, and future API formats
+where practical.
 
-## Data Source Strategy
+## Target Repository Shape
 
-WACCY keeps the core platform focused while allowing data sources to be added through extension packages. The first-party source strategy centers on QBO/QuickBooks and SEC EDGAR because they solve different parts of the small-business modeling problem.
+The current repository is Python-first. A Rust and Node architecture should grow
+into a monorepo shape like this:
+
+```text
+waccy/
+├── crates/
+│   ├── waccy-core/              # Rust schemas, ontology, validation, models
+│   ├── waccy-ffi/               # Optional FFI boundary for Python/Node
+│   └── waccy-service/           # Optional HTTP/job service
+├── python/
+│   ├── waccy/                   # Python API package
+│   ├── waccy-edgar/             # Python EDGAR adapter, if retained
+│   └── waccy-quickbooks/        # Python QBO adapter, if retained
+├── packages/
+│   └── waccy/                   # Node/TypeScript API package
+├── schemas/
+│   ├── financial-dataset.json   # Shared schema contract
+│   ├── model-output.json
+│   └── diagnostics.json
+├── docs/
+├── tests/
+│   ├── fixtures/
+│   ├── conformance/
+│   ├── python/
+│   ├── node/
+│   └── rust/
+└── examples/
+```
+
+This is a target shape, not an immediate requirement to move every file. The
+first migration should avoid churn until Rust and Node boundaries are clear.
+
+## Rust Backend
+
+Rust should become the canonical engine for financial correctness and
+performance-sensitive computation.
+
+### Crate Responsibilities
+
+`waccy-core` should own:
+
+- shared data model types
+- ontology structures
+- period and date logic
+- deterministic mapping support
+- validation and reconciliation
+- model assembly
+- serialization and diagnostics
+
+`waccy-ffi` may own:
+
+- Python binding functions
+- Node native binding functions
+- WebAssembly bindings if browser or edge use becomes important
+
+`waccy-service` may own:
+
+- HTTP/JSON API
+- async job execution
+- artifact storage hooks
+- service diagnostics
+
+These crates should be separated only when the boundary has a reason. The first
+Rust milestone can start with a single `waccy-core` crate.
+
+### Rust Data Boundary
+
+Rust should accept and emit versioned structures:
+
+- `NormalizedFinancialDataset`
+- `MappedFinancialDataset`
+- `ValidatedFinancialDataset`
+- `ThreeStatementModel`
+- `ValidationIssue`
+- `ModelDiagnostic`
+
+Serialization should be stable enough for Python and Node wrappers to rely on.
+JSON Schema is the most practical contract format for cross-language alignment;
+Arrow or binary formats can be added for large datasets later.
+
+## Python API
+
+The Python API should remain comfortable for analysts and data engineers.
+
+Responsibilities:
+
+- package ergonomics and public imports
+- pandas DataFrame export
+- XLSX export
+- notebook-friendly workflows
+- compatibility adapters for the existing `waccy` API
+- optional Python source clients where Python ecosystems are strongest
+
+As Rust parity grows, Python should delegate deterministic logic to Rust via
+bindings or service calls. Python should not maintain a separate model engine
+once Rust reaches parity.
+
+## Node API
+
+The Node API should expose WACCY to TypeScript and web product teams.
+
+Responsibilities:
+
+- npm package distribution
+- TypeScript types generated from shared schemas
+- JSON-first validation and model-building APIs
+- async-friendly calls for larger jobs
+- server-side integration with web apps and agent tools
+- optional client helpers for hosted WACCY services
+
+The Node package can be implemented through native bindings, WebAssembly, or a
+thin service client. The decision should be driven by deployment needs:
+
+- **Native binding**: best for server-side speed and direct embedding.
+- **WebAssembly**: best for portability and edge/browser possibilities.
+- **HTTP client**: best for hosted service and job orchestration.
+
+## Hosted Service Option
+
+A hosted service is not required for every deployment, but the architecture
+should allow it.
+
+Service responsibilities:
+
+- receive normalized datasets or source payloads
+- run validation and model jobs
+- store artifacts and diagnostics
+- return model outputs and export links
+- support long-running jobs for large filings or portfolios
+
+The hosted API should use the same schemas as the local Python and Node APIs.
+
+## Source Adapter Strategy
+
+Source adapters should stay outside the Rust core unless there is a clear reason
+to move them.
 
 ### QBO / QuickBooks
 
-QBO is the primary small-business accounting source. The integration should extract chart of accounts, financial statements, general ledger or transaction-level detail, and metadata needed to preserve source provenance.
-
-Architecturally, QBO data should not be trusted blindly. Source account names and account types are useful signals, but WACCY should still map them through the standard ontology and report confidence or ambiguity.
-
-The v0.1.0 QBO path keeps live API access and raw report normalization in `waccy-quickbooks`. Raw QBO `CompanyInfo`, `Account`, `ProfitAndLoss`, `BalanceSheet`, and `CashFlow` payloads are normalized into WACCY fixture-shaped source records before the core mapper, validator, model builder, XLSX exporter, or pandas handoff sees them.
+QBO remains a first-party adapter. The current Python `waccy-quickbooks` package
+can continue to own OAuth, report pulling, token cache behavior, and raw report
+normalization. Its long-term responsibility is to emit the shared normalized
+dataset.
 
 ### SEC EDGAR
 
-EDGAR serves two architectural roles:
+EDGAR remains a first-party adapter and public-company corpus. The current
+Python `waccy-edgar` package can continue to own company-facts normalization and
+filing-specific extraction until Rust or a service boundary has a strong reason
+to absorb pieces of it.
 
-- a structured public-company source for comparable financial statement data
-- a reference corpus for professional classification, terminology, and financial-statement patterns
+### Future Sources
 
-For v0.1.0, deterministic EDGAR/XBRL concept mapping is enough to support the vertical slice. Pattern learning can be added later without blocking the first model-generation path.
+Future adapters can be written in Python, Node, Rust, or another language if
+they emit the shared contract. The core should not depend on source-specific
+payload structures.
 
-### Modular Extensions
+## Ontology Architecture
 
-All other source systems should be added as modular packages that implement the same extractor contract. Examples include:
+The ontology should be stored and versioned as shared data, then loaded by Rust
+and surfaced through Python and Node.
 
-- Google Drive, Gmail, PDFs, and spreadsheets
-- banking and payment systems
-- CRM and sales systems
-- HR and payroll systems
-- ERP and inventory systems
-- market data APIs
-- other accounting systems such as Xero, Sage, and NetSuite
-
-The core platform should remain source-agnostic after extraction. All sources must normalize into the shared financial dataset contract and then map into the WACCY ontology before model construction or metric extraction.
-
-## Parsing And Classification Philosophy
-
-WACCY should use deterministic logic wherever source structures are known:
-
-- structured APIs for QBO and other accounting systems
-- XBRL/company-facts structures for EDGAR
-- explicit mappings for known account names, account types, and concepts
-- formulaic financial statement construction and reconciliation
-
-LLMs can assist where ambiguity is unavoidable:
-
-- ambiguous account names
-- incomplete context
-- document interpretation
-- classification suggestions
-- relationship inference between source records
-
-LLMs should not be the authority for financial calculations. They may propose classifications or explanations, but deterministic validation and reconciliation must remain the guardrails.
-
-## Standard Ontology Architecture
-
-The standard chart of accounts is the canonical layer between source data and model output. It should include:
+Requirements:
 
 - canonical account IDs and names
 - account type and hierarchy
 - statement placement
 - normal balance and sign convention
 - cash-flow section and treatment
-- source aliases for QBO accounts and EDGAR/XBRL concepts
-- metadata for confidence, review status, and auditability
-
-The ontology enables:
-
-- consistent model construction across sources
-- cross-company comparison
-- mapping quality measurement
-- downstream model extensibility
-- user review of ambiguous or unmapped accounts
-
-Industry-specific templates can extend the ontology, but they should map back to standard parent accounts so customization does not destroy comparability.
-
-## Project Structure
-
-### Core Package (`waccy`)
-
-The core package follows a standard Python package structure optimized for `uv`:
-
-```
-waccy/
-├── pyproject.toml          # Core dependencies and package metadata
-├── uv.lock                 # Lock file for reproducible builds
-├── README.md
-├── LICENSE
-├── CODE_OF_CONDUCT.md
-├── docs/
-│   ├── 0-MISSION.md
-│   ├── 1-EXPERIENCE.md
-│   ├── 2-REQUIREMENTS.md
-│   ├── 3-ARCHITECTURE.md
-│   ├── assets/
-│   ├── examples/
-│   └── references/
-├── src/
-│   └── waccy/
-│       ├── __init__.py
-│       ├── core/
-│       │   ├── __init__.py
-│       │   ├── ontology.py          # Standardized chart of accounts
-│       │   ├── models.py             # Core data models (Pydantic)
-│       │   └── validation.py         # Data validation (Pandera)
-│       ├── extraction/
-│       │   ├── __init__.py
-│       │   ├── base.py               # Abstract base classes for extractors
-│       │   ├── registry.py           # Extension registry and discovery
-│       │   └── mapper.py             # Mapping to standard ontology
-│       ├── modeling/
-│       │   ├── __init__.py
-│       │   ├── builder.py            # Model construction logic
-│       │   ├── templates.py          # Model templates
-│       │   └── exporters.py          # Spreadsheet export
-│       ├── classification/
-│       │   ├── __init__.py
-│       │   ├── engine.py             # LLM-enhanced classification
-│       │   ├── patterns.py           # Pattern matching from EDGAR
-│       │   └── confidence.py         # Confidence scoring
-│       └── utils/
-│           ├── __init__.py
-│           ├── dates.py
-│           ├── formatting.py
-│           └── validation.py
-├── tests/
-│   ├── __init__.py
-│   ├── unit/
-│   ├── integration/
-│   └── fixtures/
-└── scripts/
-    └── publish.py                   # PyPI publishing helper
-```
-
-### Extension Packages (`waccy-*`)
-
-Extension packages follow a consistent naming convention and structure:
-
-```
-waccy-quickbooks/
-├── pyproject.toml
-├── README.md
-├── src/
-│   └── waccy_quickbooks/
-│       ├── __init__.py
-│       ├── extractor.py             # Implements waccy.extraction.base.Extractor
-│       └── ...
-└── dist/
-
-waccy-edgar/
-├── pyproject.toml
-├── README.md
-├── src/
-│   └── waccy_edgar/
-│       ├── __init__.py
-│       ├── extractor.py             # Implements waccy.extraction.base.Extractor
-│       └── ...
-└── dist/
-```
-
-Future extension packages may add clients, parsers, mappers, and tests as implementation grows. Those files should be added when the corresponding integration work lands.
-
-## Package Configuration
-
-### Core Package (`waccy`) pyproject.toml
-
-```toml
-[project]
-name = "waccy"
-version = "0.1.0"
-description = "Intelligent financial modeling platform for small businesses"
-readme = "README.md"
-requires-python = ">=3.13"
-license = { text = "MIT" }
-authors = [
-    { name = "WACCY Contributors" }
-]
-keywords = ["finance", "financial-modeling", "accounting", "valuation"]
-classifiers = [
-    "Development Status :: 3 - Alpha",
-    "Intended Audience :: Financial and Insurance Industry",
-    "License :: OSI Approved :: MIT License",
-    "Programming Language :: Python :: 3.13",
-    "Topic :: Office/Business :: Financial",
-]
-
-dependencies = [
-    "numpy>=2.3.5",
-    "pandas>=3.0.2",
-    "pandera>=0.27.0",
-    "polars>=1.36.1",
-    "pydantic>=2.12.5",
-    # LLM providers (modular, user installs what they need)
-    # "openai>=1.0.0",  # Optional
-    # "anthropic>=0.34.0",  # Optional
-]
-
-[project.optional-dependencies]
-# Core extensions (maintained by WACCY team)
-quickbooks = ["waccy-quickbooks>=0.1.1"]
-edgar = ["waccy-edgar>=0.1.0"]
-# Community extensions listed in docs but not as dependencies
-
-[project.scripts]
-waccy = "waccy.cli:main"
-
-[build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
-
-[tool.uv]
-dev-dependencies = [
-    "pytest>=9.0.2",
-    "pytest-cov>=6.0.0",
-    "ruff>=0.8.0",
-    "mypy>=1.13.0",
-]
-
-[tool.ruff]
-line-length = 100
-target-version = "py313"
-select = [
-    "E",   # pycodestyle errors
-    "W",   # pycodestyle warnings
-    "F",   # pyflakes
-    "I",   # isort
-    "B",   # flake8-bugbear
-    "C4",  # flake8-comprehensions
-    "UP",  # pyupgrade
-    "ARG", # flake8-unused-arguments
-    "SIM", # flake8-simplify
-    "TCH", # flake8-type-checking
-    "PTH", # flake8-use-pathlib
-    "ERA", # eradicate
-    "PL",  # Pylint
-    "PERF", # Perflint
-    "RET", # flake8-return
-    "RUF", # Ruff-specific rules
-]
-ignore = [
-    "E501",  # line too long (handled by formatter)
-    "PLR0913", # too many arguments (sometimes necessary)
-    "PLR2004", # magic value (sometimes acceptable)
-]
-
-[tool.ruff.format]
-quote-style = "double"
-indent-style = "space"
-skip-magic-trailing-comma = false
-line-ending = "auto"
-
-[tool.ruff.lint.isort]
-known-first-party = ["waccy"]
-
-[tool.mypy]
-python_version = "3.13"
-warn_return_any = true
-warn_unused_configs = true
-disallow_untyped_defs = true
-disallow_incomplete_defs = true
-check_untyped_defs = true
-no_implicit_optional = true
-warn_redundant_casts = true
-warn_unused_ignores = true
-warn_no_return = true
-strict_equality = true
-
-[[tool.mypy.overrides]]
-module = "tests.*"
-disallow_untyped_defs = false
-```
-
-### Extension Package pyproject.toml Template
-
-```toml
-[project]
-name = "waccy-{name}"
-version = "0.0.1"
-description = "WACCY extension for {description}"
-readme = "README.md"
-requires-python = ">=3.13"
-license = { text = "MIT" }
-dependencies = [
-    "waccy>=0.1.0",  # Core platform dependency
-    # Extension-specific dependencies
-]
-
-[project.optional-dependencies]
-dev = [
-    "pytest>=9.0.2",
-    "ruff>=0.8.0",
-    "mypy>=1.13.0",
-]
-
-[build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
-
-# Same ruff/mypy config as core
-[tool.ruff]
-# ... (same as core)
-
-[tool.mypy]
-# ... (same as core)
-```
-
-## Core Architecture Components
-
-### 1. Extension Registry and Discovery
-
-Extensions are discovered through Python entry points, allowing dynamic loading without requiring core platform modifications.
-
-**`src/waccy/extraction/registry.py`**:
-
-```python
-from typing import Protocol, Type, Optional
-from importlib.metadata import entry_points
-
-class ExtractorProtocol(Protocol):
-    """Protocol that all extractors must implement"""
-    name: str
-    data_source: str
-    
-    def extract(self, config: dict) -> "ExtractedData":
-        ...
-
-class ExtractorRegistry:
-    """Registry for discovering and managing data source extractors"""
-    
-    def __init__(self):
-        self._extractors: dict[str, Type[ExtractorProtocol]] = {}
-        self._load_extensions()
-    
-    def _load_extensions(self):
-        """Discover extensions via entry points"""
-        discovered = entry_points(group="waccy.extractors")
-        for ep in discovered:
-            try:
-                extractor_class = ep.load()
-            except (ImportError, ModuleNotFoundError):
-                continue
-            instance = extractor_class()
-            self._extractors[instance.data_source] = extractor_class
-    
-    def get_extractor(self, data_source: str) -> Optional[Type[ExtractorProtocol]]:
-        """Get extractor class for a data source"""
-        return self._extractors.get(data_source)
-    
-    def list_extractors(self) -> list[str]:
-        """List all available data sources"""
-        return list(self._extractors.keys())
-```
-
-**Extension entry point registration** (in extension's `pyproject.toml`):
-
-```toml
-[project.entry-points."waccy.extractors"]
-quickbooks = "waccy_quickbooks.extractor:QuickBooksExtractor"
-```
-
-### 2. Standardized Ontology
-
-The core ontology defines the standard chart of accounts and account hierarchies.
-
-**`src/waccy/core/ontology.py`**:
-
-```python
-from enum import Enum
-from typing import Literal
-from pydantic import BaseModel
-
-class AccountType(str, Enum):
-    """Top-level account categories"""
-    ASSET = "asset"
-    LIABILITY = "liability"
-    EQUITY = "equity"
-    REVENUE = "revenue"
-    EXPENSE = "expense"
-
-class AccountCategory(BaseModel):
-    """Standard account category"""
-    id: str
-    name: str
-    type: AccountType
-    parent_id: Optional[str] = None
-    level: int
-    description: str
-
-class StandardChartOfAccounts:
-    """WACCY standardized chart of accounts"""
-    
-    def __init__(self):
-        self.accounts: dict[str, AccountCategory] = {}
-        self._initialize_standard_accounts()
-    
-    def _initialize_standard_accounts(self):
-        """Initialize the standard chart of accounts"""
-        # Income statement accounts
-        # Balance sheet accounts
-        # Cash flow accounts
-        # Supporting schedules
-        ...
-    
-    def map_account(self, source_account: str, source_system: str) -> Optional[AccountCategory]:
-        """Map a source account to standard account"""
-        ...
-```
-
-### 3. Base Extractor Interface
-
-All extensions must implement the base extractor interface.
-
-**`src/waccy/extraction/base.py`**:
-
-```python
-from abc import ABC, abstractmethod
-from typing import Protocol
-from pydantic import BaseModel
-
-class ExtractedTransaction(BaseModel):
-    """Standard transaction format"""
-    date: date
-    account_id: str  # Mapped to WACCY standard
-    amount: Decimal
-    description: str
-    source_id: str
-    confidence: float  # Mapping confidence score
-
-class ExtractedData(BaseModel):
-    """Standard extracted data format"""
-    transactions: list[ExtractedTransaction]
-    accounts: list[AccountCategory]
-    metadata: dict[str, Any]
-    quality_score: float
-
-class Extractor(ABC):
-    """Abstract base class for all data source extractors"""
-    
-    @property
-    @abstractmethod
-    def name(self) -> str:
-        """Extractor name"""
-        ...
-    
-    @property
-    @abstractmethod
-    def data_source(self) -> str:
-        """Data source identifier (e.g., 'quickbooks', 'edgar')"""
-        ...
-    
-    @abstractmethod
-    def authenticate(self, credentials: dict) -> bool:
-        """Authenticate with the data source"""
-        ...
-    
-    @abstractmethod
-    def extract(self, config: dict) -> ExtractedData:
-        """Extract data from the source"""
-        ...
-    
-    def validate(self, data: ExtractedData) -> bool:
-        """Validate extracted data"""
-        # Default implementation using Pandera
-        ...
-```
-
-### 4. Classification Engine
-
-LLM-enhanced classification for ambiguous account mappings.
-
-**`src/waccy/classification/engine.py`**:
-
-```python
-from typing import Optional
-from waccy.core.ontology import StandardChartOfAccounts
-
-class ClassificationEngine:
-    """LLM-powered classification for ambiguous accounts"""
-    
-    def __init__(self, llm_provider: Optional[str] = None):
-        self.ontology = StandardChartOfAccounts()
-        self.llm_provider = llm_provider
-    
-    def classify_account(
-        self, 
-        source_account_name: str,
-        transaction_patterns: list[dict],
-        context: dict
-    ) -> tuple[AccountCategory, float]:
-        """Classify an ambiguous account with confidence score"""
-        # 1. Try deterministic mapping first
-        # 2. If ambiguous, use LLM with pattern analysis
-        # 3. Validate against learned patterns from EDGAR
-        ...
-    
-    def learn_from_edgar(self, filing_data: dict):
-        """Extract classification patterns from EDGAR filings"""
-        ...
-```
-
-### 5. Model Builder
-
-Core model construction logic that works with standardized data.
-
-**`src/waccy/modeling/builder.py`**:
-
-```python
-from waccy.extraction.base import ExtractedData
-from waccy.core.ontology import StandardChartOfAccounts
-
-class ModelBuilder:
-    """Build financial models from extracted data"""
-    
-    def __init__(self):
-        self.ontology = StandardChartOfAccounts()
-    
-    def build_three_statement_model(
-        self, 
-        extracted_data: ExtractedData,
-        forecast_periods: int = 12
-    ) -> "ThreeStatementModel":
-        """Build integrated 3-statement model"""
-        # 1. Normalize extracted data to standard accounts
-        # 2. Build historical statements
-        # 3. Apply forecasting logic
-        # 4. Ensure balance checks
-        raise NotImplementedError("3-statement model not yet implemented")
-    
-    def export_to_sheets(
-        self, 
-        model: "ThreeStatementModel",
-        output_path: str
-    ):
-        """Export model to spreadsheet output."""
-        ...
-```
-
-## Extension Development Guide
-
-### Creating a New Extension
-
-1. **Create package structure**:
-```bash
-mkdir waccy-{name}
-cd waccy-{name}
-uv init --name waccy_{name} --package
-```
-
-2. **Add core dependency**:
-```toml
-dependencies = ["waccy>=0.1.0"]
-```
-
-3. **Implement Extractor**:
-```python
-# src/waccy_{name}/extractor.py
-from waccy.extraction.base import Extractor, ExtractedData
-
-class MyDataSourceExtractor(Extractor):
-    name = "My Data Source"
-    data_source = "mydatasource"
-    
-    def authenticate(self, credentials: dict) -> bool:
-        # Implement authentication
-        ...
-    
-    def extract(self, config: dict) -> ExtractedData:
-        # Extract and return standardized data
-        ...
-```
-
-4. **Register entry point**:
-```toml
-[project.entry-points."waccy.extractors"]
-mydatasource = "waccy_mydatasource.extractor:MyDataSourceExtractor"
-```
-
-5. **Publish to PyPI**:
-```bash
-uv build --no-sources
-uv publish --trusted-publishing always
-```
-
-## Development Workflow
-
-### Local Development Setup
-
-```bash
-# Clone core repository
-git clone https://github.com/waccy/waccy.git
-cd waccy
-
-# Install with uv
-uv sync
-
-# Install extension in development mode
-cd ../waccy-quickbooks
-uv sync
-uv pip install -e .
-```
-
-### Code Quality
-
-- **Ruff**: Fast linting and formatting
-  ```bash
-  ruff check .
-  ruff format .
-  ```
-
-- **Type Checking**: MyPy for static analysis
-  ```bash
-  uv run mypy src/
-  ```
-
-- **Testing**: Pytest for unit and integration tests
-  ```bash
-  uv run pytest
-  ```
-
-### Building and Publishing
-
-Local builds use uv directly and should disable workspace sources before
-release packaging:
-
-```bash
-# Build package
-uv build --no-sources
-
-# Check upload metadata locally without uploading
-uv publish --dry-run
-```
-
-Release publishing runs through `.github/workflows/publish.yml` using PyPI
-Trusted Publishers and the GitHub environment `pypi`; no long-lived PyPI token
-is required in GitHub secrets. Configure each PyPI project with:
-
-| PyPI project | Owner | Repository | Workflow | Environment |
-| --- | --- | --- | --- | --- |
-| `waccy` | `DecisionNerd` | `waccy` | `publish.yml` | `pypi` |
-| `waccy-edgar` | `DecisionNerd` | `waccy` | `publish.yml` | `pypi` |
-| `waccy-quickbooks` | `DecisionNerd` | `waccy` | `publish.yml` | `pypi` |
-
-For projects that already exist on PyPI, add the publisher under the project's
-**Publishing** settings. For a first upload of a new project, create a pending
-publisher from the account-level **Publishing** page. The same publisher can be
-registered for multiple PyPI projects in this monorepo.
-
-The GitHub `pypi` environment should be limited to deployments from `main`.
-Add required reviewers to that environment if the release process needs an
-explicit manual approval before upload.
-
-## Dependency Management
-
-### Core Dependencies
-
-Core platform maintains minimal dependencies:
-- **pydantic**: Data validation and models
-- **pandas**: DataFrame handoff for downstream modeling outside WACCY
-- **polars**: Efficient internal data manipulation where columnar performance matters
-- **pandera**: Data validation schemas
-- **numpy**: Numerical computations
-
-### Extension Dependencies
-
-Extensions manage their own dependencies:
-- Each extension's `pyproject.toml` declares dependencies
-- Core platform dependency (`waccy>=X.Y.Z`) is required
-- Extensions should minimize dependencies to reduce conflicts
-
-### Optional Dependencies
-
-LLM providers are optional and user-installed:
-- Users install `openai`, `anthropic`, etc. as needed
-- Core platform detects available providers at runtime
-- Extensions can specify preferred LLM providers
-
-## Testing Strategy
-
-### Core Platform Tests
-
-```
-tests/
-├── unit/
-│   ├── test_ontology.py
-│   ├── test_classification.py
-│   └── test_modeling.py
-├── integration/
-│   ├── test_extraction_flow.py
-│   └── test_model_generation.py
-└── fixtures/
-    └── sample_data.json
-```
-
-### Extension Tests
-
-Extensions include their own test suites:
-- Unit tests for extraction logic
-- Mock API responses for integration tests
-- Validation against core platform interfaces
-
-## Versioning Strategy
-
-- **Core Platform**: Semantic versioning (MAJOR.MINOR.PATCH)
-  - MAJOR: Breaking changes to extension interface or ontology
-  - MINOR: New features, backward-compatible
-  - PATCH: Bug fixes
-
-- **Extensions**: Independent versioning
-  - Can update independently of core
-  - Must declare minimum core version requirement
-
-## Distribution and Installation
-
-### Core Installation
-
-```bash
-# Install core platform
-uv pip install waccy
-
-# Install with core extensions
-uv pip install "waccy[quickbooks,edgar]"
-```
-
-### Extension Installation
-
-```bash
-# Install individual extensions
-uv pip install waccy-quickbooks
-uv pip install waccy-edgar
-
-# Extensions automatically register with core platform
-```
-
-### Development Installation
-
-```bash
-# Editable install for development
-uv pip install -e .
-
-# With dev dependencies
-uv sync --dev
-```
-
-## Security Considerations
-
-- **Credentials**: Never store credentials in code or config files
-- **Environment Variables**: Use environment variables or secure credential stores
-- **API Keys**: Extensions should support standard credential management
-- **Data Privacy**: Local-first processing where possible, clear data handling policies
-
-## Performance Considerations
-
-- **Polars over Pandas**: Core platform uses Polars for better performance
-- **Lazy Evaluation**: Use lazy dataframes where possible
-- **Caching**: Cache API responses and parsed data
-- **Parallel Processing**: Support parallel extraction for multiple sources
-
-## Future Architecture Considerations
-
-- **Plugin System**: More sophisticated plugin architecture for model types
-- **Workflow Engine**: Orchestrate multi-step data extraction and modeling
-- **API Server**: Optional API server for remote access
-- **Database Backend**: Optional database for data persistence
-- **GraphQL Interface**: Query interface for flexible data access
+- source aliases
+- industry extensions
+- ontology version
+
+The ontology should be testable independently from source adapters and model
+builders.
+
+## Model Builder Architecture
+
+Model builders should be organized around validated data, not source systems.
+
+Initial builder:
+
+- three-statement model
+
+Future builders:
+
+- DCF
+- comparables
+- M&A/pro forma
+- LBO
+- credit/covenant
+- SaaS metrics
+- FP&A forecast
+
+Each builder should define:
+
+- input accounts or metrics required by the builder
+- optional input accounts
+- output lines
+- subtotal and check logic
+- diagnostics
+- export representation
+
+## Testing Architecture
+
+Cross-language conformance is the key testing requirement.
+
+Test layers:
+
+- Rust unit tests for deterministic financial logic
+- Python API tests for compatibility and pandas/XLSX workflows
+- Node API tests for TypeScript contracts and JSON workflows
+- shared fixture conformance tests across Python, Node, and Rust
+- outcome tests for QBO and EDGAR release fixtures
+- package build and smoke tests for every published artifact
+
+Conformance fixtures should describe expected normalized, mapped, validated, and
+model-output results. Each language surface should prove it can produce or
+consume those fixtures.
+
+## Packaging And Release Architecture
+
+Current published packages:
+
+- PyPI: `waccy`
+- PyPI: `waccy-edgar`
+- PyPI: `waccy-quickbooks`
+
+Future packages:
+
+- crates.io: `waccy-core` or equivalent Rust crates
+- npm: `@waccy/waccy` or equivalent TypeScript package
+
+Release requirements:
+
+- package artifacts build from source without local workspace leakage
+- PyPI publishing uses trusted publishers
+- npm publishing should use provenance and trusted CI publishing where possible
+- Rust crates should use reproducible cargo builds
+- schema versions should be included in release notes
+- GitHub releases should summarize all language package versions
+
+## Migration Path
+
+This migration path follows the canonical roadmap in
+[2-REQUIREMENTS.md](2-REQUIREMENTS.md#roadmap-requirements). Architecture work
+should use these phase names so planning does not split into competing
+sequences.
+
+### Phase One: Multi-Language Contract Foundation
+
+- define shared schemas for datasets, diagnostics, and model outputs
+- align current Python models to the schema
+- add conformance fixtures
+- document compatibility expectations
+- decide which current Python APIs are compatibility commitments
+
+### Phase Two: Rust Core Parity
+
+- create `waccy-core`
+- port ontology and period/date primitives
+- port validation primitives
+- expose JSON serialization
+- prove parity on small fixtures
+- evaluate Python native binding vs service call
+- evaluate Node native binding vs WebAssembly vs service client
+- choose based on deployment and maintenance costs
+- port three-statement builder
+- port diagnostics and reconciliation
+- compare outputs against Python v0.1.0 fixtures
+- keep Python API stable
+
+### Phase Three: Service And Node API
+
+- publish TypeScript package
+- support validation and model-building calls
+- include generated types and examples
+- add Node conformance tests
+- define hosted service boundaries if local bindings are not enough
+
+### Phase Four: Advanced Models
+
+- add DCF and advanced model families on top of the validated dataset contract
+- keep Python and Node API parity where appropriate
+
+### Phase Five: Decision Support
+
+- add scenario management and sensitivity analysis
+- add model comparison workflows
+- add document and source synthesis workflows
+- expose confidence-aware review APIs for product UIs
+
+## Open Architecture Decisions
+
+- Should Python and Node call Rust through native bindings, WebAssembly, or a
+  hosted service first?
+- Should source adapters remain in Python packages or move toward language-
+  specific SDKs?
+- Should schemas be generated from Rust types or maintained as independent JSON
+  Schema files?
+- What package names should be reserved for npm and crates.io?
+- How much of XLSX export should stay in Python versus move to Rust or Node?

--- a/schemas/diagnostics.schema.json
+++ b/schemas/diagnostics.schema.json
@@ -1,0 +1,104 @@
+{
+  "$defs": {
+    "IssueSeverity": {
+      "description": "Validation issue severity.",
+      "enum": [
+        "info",
+        "warning",
+        "error"
+      ],
+      "title": "IssueSeverity",
+      "type": "string"
+    },
+    "MappingDiagnostic": {
+      "description": "Explanation for a mapping decision or issue.",
+      "properties": {
+        "code": {
+          "title": "Code",
+          "type": "string"
+        },
+        "message": {
+          "title": "Message",
+          "type": "string"
+        }
+      },
+      "required": [
+        "code",
+        "message"
+      ],
+      "title": "MappingDiagnostic",
+      "type": "object"
+    },
+    "ValidationIssue": {
+      "description": "A validation or reconciliation issue.",
+      "properties": {
+        "account_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Account Id"
+        },
+        "code": {
+          "title": "Code",
+          "type": "string"
+        },
+        "message": {
+          "title": "Message",
+          "type": "string"
+        },
+        "metadata": {
+          "additionalProperties": true,
+          "title": "Metadata",
+          "type": "object"
+        },
+        "period_label": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Period Label"
+        },
+        "severity": {
+          "$ref": "#/$defs/IssueSeverity",
+          "default": "error"
+        }
+      },
+      "required": [
+        "code",
+        "message"
+      ],
+      "title": "ValidationIssue",
+      "type": "object"
+    }
+  },
+  "$id": "https://decisionnerd.github.io/waccy/schemas/diagnostics.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Grouped schema roots for mapping and validation diagnostics.",
+  "properties": {
+    "mapping_diagnostic": {
+      "$ref": "#/$defs/MappingDiagnostic"
+    },
+    "validation_issue": {
+      "$ref": "#/$defs/ValidationIssue"
+    }
+  },
+  "required": [
+    "mapping_diagnostic",
+    "validation_issue"
+  ],
+  "title": "DiagnosticContracts",
+  "type": "object",
+  "x-waccy-generated-from": "waccy.core.models",
+  "x-waccy-schema-version": "1.0.0"
+}

--- a/schemas/financial-dataset.schema.json
+++ b/schemas/financial-dataset.schema.json
@@ -37,6 +37,7 @@
           "type": "array"
         },
         "schema_version": {
+          "const": "1.0.0",
           "default": "1.0.0",
           "title": "Schema Version",
           "type": "string"
@@ -45,7 +46,8 @@
       "required": [
         "entity_name",
         "periods",
-        "records"
+        "records",
+        "schema_version"
       ],
       "title": "MappedFinancialDataset",
       "type": "object"
@@ -174,6 +176,7 @@
           "type": "array"
         },
         "schema_version": {
+          "const": "1.0.0",
           "default": "1.0.0",
           "title": "Schema Version",
           "type": "string"
@@ -182,7 +185,8 @@
       "required": [
         "entity_name",
         "periods",
-        "records"
+        "records",
+        "schema_version"
       ],
       "title": "NormalizedFinancialDataset",
       "type": "object"
@@ -345,13 +349,15 @@
           "$ref": "#/$defs/MappedFinancialDataset"
         },
         "schema_version": {
+          "const": "1.0.0",
           "default": "1.0.0",
           "title": "Schema Version",
           "type": "string"
         }
       },
       "required": [
-        "mapped_dataset"
+        "mapped_dataset",
+        "schema_version"
       ],
       "title": "ValidatedFinancialDataset",
       "type": "object"

--- a/schemas/financial-dataset.schema.json
+++ b/schemas/financial-dataset.schema.json
@@ -1,0 +1,435 @@
+{
+  "$defs": {
+    "IssueSeverity": {
+      "description": "Validation issue severity.",
+      "enum": [
+        "info",
+        "warning",
+        "error"
+      ],
+      "title": "IssueSeverity",
+      "type": "string"
+    },
+    "MappedFinancialDataset": {
+      "description": "Normalized financial data after source-to-standard account mapping.",
+      "properties": {
+        "entity_name": {
+          "title": "Entity Name",
+          "type": "string"
+        },
+        "metadata": {
+          "additionalProperties": true,
+          "title": "Metadata",
+          "type": "object"
+        },
+        "periods": {
+          "items": {
+            "$ref": "#/$defs/ReportingPeriod"
+          },
+          "title": "Periods",
+          "type": "array"
+        },
+        "records": {
+          "items": {
+            "$ref": "#/$defs/MappedFinancialRecord"
+          },
+          "title": "Records",
+          "type": "array"
+        },
+        "schema_version": {
+          "default": "1.0.0",
+          "title": "Schema Version",
+          "type": "string"
+        }
+      },
+      "required": [
+        "entity_name",
+        "periods",
+        "records"
+      ],
+      "title": "MappedFinancialDataset",
+      "type": "object"
+    },
+    "MappedFinancialRecord": {
+      "description": "A normalized record mapped to the WACCY ontology.",
+      "properties": {
+        "account_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Account Id"
+        },
+        "account_name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Account Name"
+        },
+        "confidence": {
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Confidence",
+          "type": "number"
+        },
+        "diagnostics": {
+          "items": {
+            "$ref": "#/$defs/MappingDiagnostic"
+          },
+          "title": "Diagnostics",
+          "type": "array"
+        },
+        "override_note": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Override Note"
+        },
+        "source_record": {
+          "$ref": "#/$defs/SourceRecord"
+        },
+        "status": {
+          "$ref": "#/$defs/MappingStatus"
+        }
+      },
+      "required": [
+        "source_record",
+        "status",
+        "confidence"
+      ],
+      "title": "MappedFinancialRecord",
+      "type": "object"
+    },
+    "MappingDiagnostic": {
+      "description": "Explanation for a mapping decision or issue.",
+      "properties": {
+        "code": {
+          "title": "Code",
+          "type": "string"
+        },
+        "message": {
+          "title": "Message",
+          "type": "string"
+        }
+      },
+      "required": [
+        "code",
+        "message"
+      ],
+      "title": "MappingDiagnostic",
+      "type": "object"
+    },
+    "MappingStatus": {
+      "description": "Review state for a source-to-standard account mapping.",
+      "enum": [
+        "mapped",
+        "ambiguous",
+        "overridden",
+        "unmapped"
+      ],
+      "title": "MappingStatus",
+      "type": "string"
+    },
+    "NormalizedFinancialDataset": {
+      "description": "Source-agnostic records with source-native account/concept identity preserved.",
+      "properties": {
+        "entity_name": {
+          "title": "Entity Name",
+          "type": "string"
+        },
+        "metadata": {
+          "additionalProperties": true,
+          "title": "Metadata",
+          "type": "object"
+        },
+        "periods": {
+          "items": {
+            "$ref": "#/$defs/ReportingPeriod"
+          },
+          "title": "Periods",
+          "type": "array"
+        },
+        "records": {
+          "items": {
+            "$ref": "#/$defs/SourceRecord"
+          },
+          "title": "Records",
+          "type": "array"
+        },
+        "schema_version": {
+          "default": "1.0.0",
+          "title": "Schema Version",
+          "type": "string"
+        }
+      },
+      "required": [
+        "entity_name",
+        "periods",
+        "records"
+      ],
+      "title": "NormalizedFinancialDataset",
+      "type": "object"
+    },
+    "PeriodType": {
+      "description": "Supported reporting period granularities.",
+      "enum": [
+        "month",
+        "quarter",
+        "year"
+      ],
+      "title": "PeriodType",
+      "type": "string"
+    },
+    "ReportingPeriod": {
+      "description": "A reporting period used as a model column.",
+      "properties": {
+        "end_date": {
+          "format": "date",
+          "title": "End Date",
+          "type": "string"
+        },
+        "label": {
+          "title": "Label",
+          "type": "string"
+        },
+        "period_type": {
+          "$ref": "#/$defs/PeriodType",
+          "default": "year"
+        },
+        "start_date": {
+          "format": "date",
+          "title": "Start Date",
+          "type": "string"
+        }
+      },
+      "required": [
+        "label",
+        "start_date",
+        "end_date"
+      ],
+      "title": "ReportingPeriod",
+      "type": "object"
+    },
+    "SourceRecord": {
+      "description": "A source-shaped financial record before WACCY account mapping.",
+      "properties": {
+        "amount": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+              "type": "string"
+            }
+          ],
+          "title": "Amount"
+        },
+        "metadata": {
+          "additionalProperties": true,
+          "title": "Metadata",
+          "type": "object"
+        },
+        "period_label": {
+          "title": "Period Label",
+          "type": "string"
+        },
+        "source": {
+          "$ref": "#/$defs/SourceReference"
+        },
+        "source_account_id": {
+          "title": "Source Account Id",
+          "type": "string"
+        },
+        "source_account_name": {
+          "title": "Source Account Name",
+          "type": "string"
+        },
+        "source_account_type": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Source Account Type"
+        },
+        "statement": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Statement"
+        },
+        "unit": {
+          "default": "USD",
+          "title": "Unit",
+          "type": "string"
+        }
+      },
+      "required": [
+        "source_account_id",
+        "source_account_name",
+        "amount",
+        "period_label",
+        "source"
+      ],
+      "title": "SourceRecord",
+      "type": "object"
+    },
+    "SourceReference": {
+      "description": "Pointer back to a source system record.",
+      "properties": {
+        "metadata": {
+          "additionalProperties": true,
+          "title": "Metadata",
+          "type": "object"
+        },
+        "source_id": {
+          "title": "Source Id",
+          "type": "string"
+        },
+        "source_label": {
+          "default": "",
+          "title": "Source Label",
+          "type": "string"
+        },
+        "source_system": {
+          "title": "Source System",
+          "type": "string"
+        }
+      },
+      "required": [
+        "source_system",
+        "source_id"
+      ],
+      "title": "SourceReference",
+      "type": "object"
+    },
+    "ValidatedFinancialDataset": {
+      "description": "Mapped financial data plus validation diagnostics.",
+      "properties": {
+        "issues": {
+          "items": {
+            "$ref": "#/$defs/ValidationIssue"
+          },
+          "title": "Issues",
+          "type": "array"
+        },
+        "mapped_dataset": {
+          "$ref": "#/$defs/MappedFinancialDataset"
+        },
+        "schema_version": {
+          "default": "1.0.0",
+          "title": "Schema Version",
+          "type": "string"
+        }
+      },
+      "required": [
+        "mapped_dataset"
+      ],
+      "title": "ValidatedFinancialDataset",
+      "type": "object"
+    },
+    "ValidationIssue": {
+      "description": "A validation or reconciliation issue.",
+      "properties": {
+        "account_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Account Id"
+        },
+        "code": {
+          "title": "Code",
+          "type": "string"
+        },
+        "message": {
+          "title": "Message",
+          "type": "string"
+        },
+        "metadata": {
+          "additionalProperties": true,
+          "title": "Metadata",
+          "type": "object"
+        },
+        "period_label": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Period Label"
+        },
+        "severity": {
+          "$ref": "#/$defs/IssueSeverity",
+          "default": "error"
+        }
+      },
+      "required": [
+        "code",
+        "message"
+      ],
+      "title": "ValidationIssue",
+      "type": "object"
+    }
+  },
+  "$id": "https://decisionnerd.github.io/waccy/schemas/financial-dataset.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Grouped schema roots for dataset contract consumers.",
+  "properties": {
+    "mapped_financial_dataset": {
+      "$ref": "#/$defs/MappedFinancialDataset"
+    },
+    "normalized_financial_dataset": {
+      "$ref": "#/$defs/NormalizedFinancialDataset"
+    },
+    "validated_financial_dataset": {
+      "$ref": "#/$defs/ValidatedFinancialDataset"
+    }
+  },
+  "required": [
+    "normalized_financial_dataset",
+    "mapped_financial_dataset",
+    "validated_financial_dataset"
+  ],
+  "title": "FinancialDatasetContracts",
+  "type": "object",
+  "x-waccy-generated-from": "waccy.core.models",
+  "x-waccy-schema-version": "1.0.0"
+}

--- a/schemas/model-output.schema.json
+++ b/schemas/model-output.schema.json
@@ -1,0 +1,257 @@
+{
+  "$defs": {
+    "FinancialStatement": {
+      "description": "A financial statement composed of ordered line items.",
+      "properties": {
+        "lines": {
+          "items": {
+            "$ref": "#/$defs/StatementLine"
+          },
+          "title": "Lines",
+          "type": "array"
+        },
+        "name": {
+          "enum": [
+            "Income Statement",
+            "Balance Sheet",
+            "Cash Flow Statement"
+          ],
+          "title": "Name",
+          "type": "string"
+        },
+        "periods": {
+          "items": {
+            "$ref": "#/$defs/ReportingPeriod"
+          },
+          "title": "Periods",
+          "type": "array"
+        }
+      },
+      "required": [
+        "name",
+        "periods",
+        "lines"
+      ],
+      "title": "FinancialStatement",
+      "type": "object"
+    },
+    "IssueSeverity": {
+      "description": "Validation issue severity.",
+      "enum": [
+        "info",
+        "warning",
+        "error"
+      ],
+      "title": "IssueSeverity",
+      "type": "string"
+    },
+    "PeriodType": {
+      "description": "Supported reporting period granularities.",
+      "enum": [
+        "month",
+        "quarter",
+        "year"
+      ],
+      "title": "PeriodType",
+      "type": "string"
+    },
+    "ReportingPeriod": {
+      "description": "A reporting period used as a model column.",
+      "properties": {
+        "end_date": {
+          "format": "date",
+          "title": "End Date",
+          "type": "string"
+        },
+        "label": {
+          "title": "Label",
+          "type": "string"
+        },
+        "period_type": {
+          "$ref": "#/$defs/PeriodType",
+          "default": "year"
+        },
+        "start_date": {
+          "format": "date",
+          "title": "Start Date",
+          "type": "string"
+        }
+      },
+      "required": [
+        "label",
+        "start_date",
+        "end_date"
+      ],
+      "title": "ReportingPeriod",
+      "type": "object"
+    },
+    "StatementLine": {
+      "description": "A line item in a financial statement.",
+      "properties": {
+        "account_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Account Id"
+        },
+        "is_check": {
+          "default": false,
+          "title": "Is Check",
+          "type": "boolean"
+        },
+        "is_subtotal": {
+          "default": false,
+          "title": "Is Subtotal",
+          "type": "boolean"
+        },
+        "label": {
+          "title": "Label",
+          "type": "string"
+        },
+        "metadata": {
+          "additionalProperties": true,
+          "title": "Metadata",
+          "type": "object"
+        },
+        "source_account_ids": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Source Account Ids",
+          "type": "array"
+        },
+        "values": {
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              }
+            ]
+          },
+          "title": "Values",
+          "type": "object"
+        }
+      },
+      "required": [
+        "label"
+      ],
+      "title": "StatementLine",
+      "type": "object"
+    },
+    "ValidationIssue": {
+      "description": "A validation or reconciliation issue.",
+      "properties": {
+        "account_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Account Id"
+        },
+        "code": {
+          "title": "Code",
+          "type": "string"
+        },
+        "message": {
+          "title": "Message",
+          "type": "string"
+        },
+        "metadata": {
+          "additionalProperties": true,
+          "title": "Metadata",
+          "type": "object"
+        },
+        "period_label": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Period Label"
+        },
+        "severity": {
+          "$ref": "#/$defs/IssueSeverity",
+          "default": "error"
+        }
+      },
+      "required": [
+        "code",
+        "message"
+      ],
+      "title": "ValidationIssue",
+      "type": "object"
+    }
+  },
+  "$id": "https://decisionnerd.github.io/waccy/schemas/model-output.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Source-agnostic three-statement model output.",
+  "properties": {
+    "balance_sheet": {
+      "$ref": "#/$defs/FinancialStatement"
+    },
+    "cash_flow_statement": {
+      "$ref": "#/$defs/FinancialStatement"
+    },
+    "entity_name": {
+      "title": "Entity Name",
+      "type": "string"
+    },
+    "income_statement": {
+      "$ref": "#/$defs/FinancialStatement"
+    },
+    "metadata": {
+      "additionalProperties": true,
+      "title": "Metadata",
+      "type": "object"
+    },
+    "periods": {
+      "items": {
+        "$ref": "#/$defs/ReportingPeriod"
+      },
+      "title": "Periods",
+      "type": "array"
+    },
+    "schema_version": {
+      "default": "1.0.0",
+      "title": "Schema Version",
+      "type": "string"
+    },
+    "validation_issues": {
+      "items": {
+        "$ref": "#/$defs/ValidationIssue"
+      },
+      "title": "Validation Issues",
+      "type": "array"
+    }
+  },
+  "required": [
+    "entity_name",
+    "periods",
+    "income_statement",
+    "balance_sheet",
+    "cash_flow_statement"
+  ],
+  "title": "ThreeStatementModel",
+  "type": "object",
+  "x-waccy-generated-from": "waccy.core.models",
+  "x-waccy-schema-version": "1.0.0"
+}

--- a/schemas/model-output.schema.json
+++ b/schemas/model-output.schema.json
@@ -231,6 +231,7 @@
       "type": "array"
     },
     "schema_version": {
+      "const": "1.0.0",
       "default": "1.0.0",
       "title": "Schema Version",
       "type": "string"
@@ -244,11 +245,12 @@
     }
   },
   "required": [
-    "entity_name",
-    "periods",
-    "income_statement",
     "balance_sheet",
-    "cash_flow_statement"
+    "cash_flow_statement",
+    "entity_name",
+    "income_statement",
+    "periods",
+    "schema_version"
   ],
   "title": "ThreeStatementModel",
   "type": "object",

--- a/scripts/generate-schemas.py
+++ b/scripts/generate-schemas.py
@@ -1,0 +1,107 @@
+"""Generate WACCY JSON Schema artifacts from the Python contract models."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel
+
+from waccy.core.models import (
+    CONTRACT_SCHEMA_VERSION,
+    MappedFinancialDataset,
+    MappingDiagnostic,
+    NormalizedFinancialDataset,
+    ThreeStatementModel,
+    ValidatedFinancialDataset,
+    ValidationIssue,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_DIR = ROOT / "schemas"
+
+
+class FinancialDatasetContracts(BaseModel):
+    """Grouped schema roots for dataset contract consumers."""
+
+    normalized_financial_dataset: NormalizedFinancialDataset
+    mapped_financial_dataset: MappedFinancialDataset
+    validated_financial_dataset: ValidatedFinancialDataset
+
+
+class DiagnosticContracts(BaseModel):
+    """Grouped schema roots for mapping and validation diagnostics."""
+
+    mapping_diagnostic: MappingDiagnostic
+    validation_issue: ValidationIssue
+
+
+SCHEMAS: dict[str, type[BaseModel]] = {
+    "financial-dataset.schema.json": FinancialDatasetContracts,
+    "model-output.schema.json": ThreeStatementModel,
+    "diagnostics.schema.json": DiagnosticContracts,
+}
+
+
+def _schema_for(model: type[BaseModel], filename: str) -> dict[str, Any]:
+    schema = model.model_json_schema()
+    schema["$id"] = f"https://decisionnerd.github.io/waccy/schemas/{filename}"
+    schema["$schema"] = "https://json-schema.org/draft/2020-12/schema"
+    schema["x-waccy-schema-version"] = CONTRACT_SCHEMA_VERSION
+    schema["x-waccy-generated-from"] = "waccy.core.models"
+    return schema
+
+
+def render_schemas() -> dict[str, str]:
+    """Return deterministic schema file contents keyed by filename."""
+    return {
+        filename: json.dumps(_schema_for(model, filename), indent=2, sort_keys=True) + "\n"
+        for filename, model in SCHEMAS.items()
+    }
+
+
+def write_schemas() -> None:
+    """Write generated schemas to the repository schema directory."""
+    SCHEMA_DIR.mkdir(exist_ok=True)
+    for filename, content in render_schemas().items():
+        (SCHEMA_DIR / filename).write_text(content)
+
+
+def check_schemas() -> list[str]:
+    """Return names of schema artifacts that differ from generated output."""
+    mismatches = []
+    for filename, content in render_schemas().items():
+        path = SCHEMA_DIR / filename
+        if not path.exists() or path.read_text() != content:
+            mismatches.append(filename)
+    return mismatches
+
+
+def main() -> int:
+    """Run the schema generator or drift check."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="fail if committed schema artifacts differ from generated output",
+    )
+    args = parser.parse_args()
+
+    if args.check:
+        mismatches = check_schemas()
+        if mismatches:
+            joined = ", ".join(mismatches)
+            print(f"Schema artifacts are out of date: {joined}")
+            return 1
+        print("Schema artifacts are current.")
+        return 0
+
+    write_schemas()
+    print(f"Wrote {len(SCHEMAS)} schema artifacts to {SCHEMA_DIR.relative_to(ROOT)}.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/generate-schemas.py
+++ b/scripts/generate-schemas.py
@@ -47,11 +47,34 @@ SCHEMAS: dict[str, type[BaseModel]] = {
 
 def _schema_for(model: type[BaseModel], filename: str) -> dict[str, Any]:
     schema = model.model_json_schema()
+    _enforce_schema_version_contract(schema)
     schema["$id"] = f"https://decisionnerd.github.io/waccy/schemas/{filename}"
     schema["$schema"] = "https://json-schema.org/draft/2020-12/schema"
     schema["x-waccy-schema-version"] = CONTRACT_SCHEMA_VERSION
     schema["x-waccy-generated-from"] = "waccy.core.models"
     return schema
+
+
+def _enforce_schema_version_contract(schema: dict[str, Any]) -> None:
+    """Require schema_version consts on generated contract objects that define it."""
+    properties = schema.get("properties")
+    if isinstance(properties, dict) and "schema_version" in properties:
+        schema_version = properties["schema_version"]
+        if isinstance(schema_version, dict):
+            schema_version["const"] = CONTRACT_SCHEMA_VERSION
+            schema_version["default"] = CONTRACT_SCHEMA_VERSION
+        required = schema.setdefault("required", [])
+        if isinstance(required, list) and "schema_version" not in required:
+            required.append("schema_version")
+            required.sort()
+
+    for value in schema.values():
+        if isinstance(value, dict):
+            _enforce_schema_version_contract(value)
+        elif isinstance(value, list):
+            for item in value:
+                if isinstance(item, dict):
+                    _enforce_schema_version_contract(item)
 
 
 def render_schemas() -> dict[str, str]:

--- a/src/waccy/__init__.py
+++ b/src/waccy/__init__.py
@@ -6,6 +6,7 @@ __version__ = "0.1.0"
 # Classification exports
 from waccy.classification import ClassificationEngine
 from waccy.core import (
+    CONTRACT_SCHEMA_VERSION,
     AccountCategory,
     AccountType,
     ExtractedData,
@@ -21,6 +22,7 @@ from waccy.extraction import Extractor, ExtractorRegistry
 from waccy.modeling import ModelBuilder
 
 __all__ = [
+    "CONTRACT_SCHEMA_VERSION",
     "AccountCategory",
     "AccountType",
     "ClassificationEngine",

--- a/src/waccy/core/__init__.py
+++ b/src/waccy/core/__init__.py
@@ -1,6 +1,7 @@
 """Core platform components: ontology, models, and validation."""
 
 from waccy.core.models import (
+    CONTRACT_SCHEMA_VERSION,
     ExtractedData,
     ExtractedTransaction,
     FinancialStatement,
@@ -24,6 +25,7 @@ from waccy.core.ontology import AccountCategory, AccountType, StandardChartOfAcc
 from waccy.core.validation import validate_extracted_data, validate_mapped_dataset
 
 __all__ = [
+    "CONTRACT_SCHEMA_VERSION",
     "AccountCategory",
     "AccountType",
     "ExtractedData",

--- a/src/waccy/core/models.py
+++ b/src/waccy/core/models.py
@@ -9,6 +9,8 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
+CONTRACT_SCHEMA_VERSION = "1.0.0"
+
 
 class PeriodType(str, Enum):
     """Supported reporting period granularities."""
@@ -70,6 +72,7 @@ class SourceRecord(BaseModel):
 class NormalizedFinancialDataset(BaseModel):
     """Source-agnostic records with source-native account/concept identity preserved."""
 
+    schema_version: str = CONTRACT_SCHEMA_VERSION
     entity_name: str
     periods: list[ReportingPeriod]
     records: list[SourceRecord]
@@ -105,6 +108,7 @@ class MappedFinancialRecord(BaseModel):
 class MappedFinancialDataset(BaseModel):
     """Normalized financial data after source-to-standard account mapping."""
 
+    schema_version: str = CONTRACT_SCHEMA_VERSION
     entity_name: str
     periods: list[ReportingPeriod]
     records: list[MappedFinancialRecord]
@@ -125,6 +129,7 @@ class ValidationIssue(BaseModel):
 class ValidatedFinancialDataset(BaseModel):
     """Mapped financial data plus validation diagnostics."""
 
+    schema_version: str = CONTRACT_SCHEMA_VERSION
     mapped_dataset: MappedFinancialDataset
     issues: list[ValidationIssue] = Field(default_factory=list)
 
@@ -200,6 +205,7 @@ class FinancialStatement(BaseModel):
 class ThreeStatementModel(BaseModel):
     """Source-agnostic three-statement model output."""
 
+    schema_version: str = CONTRACT_SCHEMA_VERSION
     entity_name: str
     periods: list[ReportingPeriod]
     income_statement: FinancialStatement

--- a/tests/unit/test_schemas.py
+++ b/tests/unit/test_schemas.py
@@ -67,6 +67,26 @@ def test_committed_schema_artifacts_include_expected_contracts() -> None:
         assert expectation["defs"].issubset(schema.get("$defs", {}))
 
 
+def test_contract_schema_version_is_required_and_const() -> None:
+    """Generated schemas enforce payload-level schema_version compatibility."""
+    financial_dataset = json.loads((SCHEMA_DIR / "financial-dataset.schema.json").read_text())
+    model_output = json.loads((SCHEMA_DIR / "model-output.schema.json").read_text())
+    diagnostics = json.loads((SCHEMA_DIR / "diagnostics.schema.json").read_text())
+
+    for name in (
+        "NormalizedFinancialDataset",
+        "MappedFinancialDataset",
+        "ValidatedFinancialDataset",
+    ):
+        definition = financial_dataset["$defs"][name]
+        assert "schema_version" in definition["required"]
+        assert definition["properties"]["schema_version"]["const"] == CONTRACT_SCHEMA_VERSION
+
+    assert "schema_version" in model_output["required"]
+    assert model_output["properties"]["schema_version"]["const"] == CONTRACT_SCHEMA_VERSION
+    assert "schema_version" not in diagnostics.get("properties", {})
+
+
 def test_schema_generator_matches_committed_artifacts() -> None:
     """Generated Pydantic schemas match the committed JSON artifacts."""
     generator = _load_schema_generator()

--- a/tests/unit/test_schemas.py
+++ b/tests/unit/test_schemas.py
@@ -1,0 +1,86 @@
+"""Shared JSON Schema contract tests."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from waccy.core.models import (
+    CONTRACT_SCHEMA_VERSION,
+    MappedFinancialDataset,
+    NormalizedFinancialDataset,
+    ThreeStatementModel,
+    ValidatedFinancialDataset,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+SCHEMA_DIR = ROOT / "schemas"
+GENERATOR_PATH = ROOT / "scripts" / "generate-schemas.py"
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+
+def test_root_contract_models_have_schema_version_default() -> None:
+    """Root polyglot contract models expose the current schema version."""
+    for model in (
+        NormalizedFinancialDataset,
+        MappedFinancialDataset,
+        ValidatedFinancialDataset,
+        ThreeStatementModel,
+    ):
+        assert model.model_fields["schema_version"].default == CONTRACT_SCHEMA_VERSION
+
+
+def test_committed_schema_artifacts_include_expected_contracts() -> None:
+    """Schema artifacts are loadable and expose stable WACCY metadata."""
+    expected = {
+        "financial-dataset.schema.json": {
+            "title": "FinancialDatasetContracts",
+            "defs": {
+                "NormalizedFinancialDataset",
+                "MappedFinancialDataset",
+                "ValidatedFinancialDataset",
+            },
+        },
+        "model-output.schema.json": {
+            "title": "ThreeStatementModel",
+            "defs": {"FinancialStatement", "StatementLine", "ValidationIssue"},
+        },
+        "diagnostics.schema.json": {
+            "title": "DiagnosticContracts",
+            "defs": {"MappingDiagnostic", "ValidationIssue"},
+        },
+    }
+
+    for filename, expectation in expected.items():
+        schema = json.loads((SCHEMA_DIR / filename).read_text())
+
+        assert schema["$schema"] == "https://json-schema.org/draft/2020-12/schema"
+        assert schema["$id"] == f"https://decisionnerd.github.io/waccy/schemas/{filename}"
+        assert schema["x-waccy-schema-version"] == CONTRACT_SCHEMA_VERSION
+        assert schema["x-waccy-generated-from"] == "waccy.core.models"
+        assert schema["title"] == expectation["title"]
+        assert expectation["defs"].issubset(schema.get("$defs", {}))
+
+
+def test_schema_generator_matches_committed_artifacts() -> None:
+    """Generated Pydantic schemas match the committed JSON artifacts."""
+    generator = _load_schema_generator()
+
+    assert generator.check_schemas() == []
+    for filename, content in generator.render_schemas().items():
+        assert (SCHEMA_DIR / filename).read_text() == content
+
+
+def _load_schema_generator() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("waccy_schema_generator", GENERATOR_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("Could not load schema generator.")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module


### PR DESCRIPTION
## Summary
- rewrite requirements around the new Python API, Node API, and Rust backend direction
- rewrite architecture around a Rust canonical engine with Python and Node API surfaces
- define target repo shape, shared schemas, conformance tests, source adapter strategy, and migration phases

## Validation
- make docs-build

## Notes
- Leaves existing v0.1.0 Python implementation framed as the reference behavior during migration.
- Leaves unrelated untracked local file `.coverage 2` untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Rewrote requirements and architecture to define a polyglot platform, cross-language data contracts, expanded model families, exporters/API expectations, source priorities, versioning/migration, phased roadmap, and conformance testing.

* **Schemas**
  * Added formal JSON Schemas for diagnostics, financial datasets, and model outputs with schema-version metadata and validation rules.

* **Tooling**
  * Added a schema generator/checker to produce and verify canonical schema artifacts.

* **Tests**
  * Added schema conformance tests validating committed artifacts and generator output.

* **New Features**
  * Model/dataset payloads now include a public schema_version constant exposed in the package.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DecisionNerd/waccy/pull/37?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #43